### PR TITLE
Prevent default on drag toast

### DIFF
--- a/src/components/VtToast.vue
+++ b/src/components/VtToast.vue
@@ -196,7 +196,7 @@ export default Vue.extend({
       const element = this.$el as HTMLElement;
       element.addEventListener("touchstart", this.onDragStart);
       element.addEventListener("mousedown", this.onDragStart);
-      addEventListener("touchmove", this.onDragMove);
+      addEventListener("touchmove", this.onDragMove, { passive: false });
       addEventListener("mousemove", this.onDragMove);
       addEventListener("touchend", this.onDragEnd);
       addEventListener("mouseup", this.onDragEnd);
@@ -219,6 +219,7 @@ export default Vue.extend({
     },
     onDragMove(event: TouchEvent | MouseEvent) {
       if (this.beingDragged) {
+        event.preventDefault();
         if (this.isRunning) {
           this.isRunning = false;
         }

--- a/tests/unit/components/VtToast.spec.ts
+++ b/tests/unit/components/VtToast.spec.ts
@@ -570,6 +570,19 @@ describe("VtToast", () => {
       expect(vm.isRunning).toBe(false);
       expect(vm.dragPos).toEqual({ x: 20, y: 25 });
     });
+    it("event.preventDefault is called if being dragged", () => {
+      const wrapper = mountToast({ draggable: true });
+      wrapper.setData({ beingDragged: false, isRunning: true });
+      wrapper.trigger("mousedown", {
+        clientX: 0,
+        clientY: 0
+      });
+      const event = new MouseEvent("mousemove", { clientX: 10, clientY: 15 });
+      const spyPreventDefault = jest.spyOn(event, "preventDefault");
+      expect(spyPreventDefault).not.toBeCalled();
+      window.dispatchEvent(event);
+      expect(spyPreventDefault).toBeCalled();
+    });
     it("does nothing if not beingDragged", () => {
       const wrapper = mountToast({ draggable: true });
       const docWrapper = createWrapper(document.body);


### PR DESCRIPTION
Fixes issue where dragging the toast would scroll on mobile and select text on the desktop.
Resolves #51 

![CleanShot 2020-03-20 at 01 05 40](https://user-images.githubusercontent.com/19658460/77134716-ff32dd80-6a46-11ea-87ec-1e05f96e3a78.gif)
