### PR TITLE
Fix black close button on mobile

### DIFF
--- a/src/components/VtCloseButton.vue
+++ b/src/components/VtCloseButton.vue
@@ -5,7 +5,7 @@
     :class="classes"
     v-on="$listeners"
   >
-    ✖
+    &times;
   </component>
 </template>
 <script lang="ts">

--- a/src/scss/_closeButton.scss
+++ b/src/scss/_closeButton.scss
@@ -1,6 +1,7 @@
 .#{$vt-namespace}__close-button {
     font-weight: bold;
-    font-size: 16px;
+    font-size: 24px;
+    line-height: 24px;
     background: transparent;
     outline: none;
     border: none;

--- a/tests/unit/components/__snapshots__/VtCloseButton.spec.ts.snap
+++ b/tests/unit/components/__snapshots__/VtCloseButton.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`VtCloseButton adds 'show-on-hover' class 1`] = `
   class="Vue-Toastification__close-button"
 >
   
-  ✖
+  ×
 
 </button>
 `;
@@ -17,7 +17,7 @@ exports[`VtCloseButton adds 'show-on-hover' class 2`] = `
   class="Vue-Toastification__close-button show-on-hover"
 >
   
-  ✖
+  ×
 
 </button>
 `;
@@ -28,7 +28,7 @@ exports[`VtCloseButton adds custom class array 1`] = `
   class="Vue-Toastification__close-button my-class my-class2"
 >
   
-  ✖
+  ×
 
 </button>
 `;
@@ -39,7 +39,7 @@ exports[`VtCloseButton adds custom class string 1`] = `
   class="Vue-Toastification__close-button my-class"
 >
   
-  ✖
+  ×
 
 </button>
 `;
@@ -50,7 +50,7 @@ exports[`VtCloseButton matches default snapshot 1`] = `
   class="Vue-Toastification__close-button"
 >
   
-  ✖
+  ×
 
 </button>
 `;
@@ -61,7 +61,7 @@ exports[`VtCloseButton renders custom aria label 1`] = `
   class="Vue-Toastification__close-button"
 >
   
-  ✖
+  ×
 
 </button>
 `;
@@ -72,7 +72,7 @@ exports[`VtCloseButton renders default aria label 1`] = `
   class="Vue-Toastification__close-button"
 >
   
-  ✖
+  ×
 
 </button>
 `;
@@ -83,7 +83,7 @@ exports[`VtCloseButton string custom component 1`] = `
   class="Vue-Toastification__close-button"
 >
   
-  ✖
+  ×
 
 </div>
 `;

--- a/tests/unit/components/__snapshots__/VtToast.spec.ts.snap
+++ b/tests/unit/components/__snapshots__/VtToast.spec.ts.snap
@@ -32,7 +32,7 @@ exports[`VtToast snapshots renders 1`] = `
     class="Vue-Toastification__close-button"
   >
     
-  ✖
+  ×
 
   </button>
    
@@ -111,7 +111,7 @@ exports[`VtToast ui has all default sub components 1`] = `
     class="Vue-Toastification__close-button"
   >
     
-  ✖
+  ×
 
   </button>
    
@@ -140,7 +140,7 @@ exports[`VtToast ui icon = false removes it 1`] = `
     class="Vue-Toastification__close-button"
   >
     
-  ✖
+  ×
 
   </button>
    
@@ -183,7 +183,7 @@ exports[`VtToast ui renders custom aria role and button aria label 1`] = `
     class="Vue-Toastification__close-button"
   >
     
-  ✖
+  ×
 
   </button>
    
@@ -230,7 +230,7 @@ exports[`VtToast ui renders custom component 1`] = `
     class="Vue-Toastification__close-button"
   >
     
-  ✖
+  ×
 
   </button>
    
@@ -273,7 +273,7 @@ exports[`VtToast ui renders default aria role and button aria label 1`] = `
     class="Vue-Toastification__close-button"
   >
     
-  ✖
+  ×
 
   </button>
    
@@ -316,7 +316,7 @@ exports[`VtToast ui renders ltr by default 1`] = `
     class="Vue-Toastification__close-button"
   >
     
-  ✖
+  ×
 
   </button>
    
@@ -359,7 +359,7 @@ exports[`VtToast ui renders rtl if set 1`] = `
     class="Vue-Toastification__close-button"
   >
     
-  ✖
+  ×
 
   </button>
    
@@ -402,7 +402,7 @@ exports[`VtToast ui timeout = false removes progress bar 1`] = `
     class="Vue-Toastification__close-button"
   >
     
-  ✖
+  ×
 
   </button>
    


### PR DESCRIPTION
resolves #59 

To fix the issue, the close button text had to be changed. Because of that, it goes from looking like this:
![image](https://user-images.githubusercontent.com/19658460/77214972-6d7faa80-6af0-11ea-9934-8e7e6af755f7.png)

To looking like this:
![image](https://user-images.githubusercontent.com/19658460/77214960-5f318e80-6af0-11ea-9ad8-eb3cc315607f.png)
