### PR TITLE
Support newlines on toasts

### DIFF
--- a/src/scss/_toast.scss
+++ b/src/scss/_toast.scss
@@ -50,6 +50,7 @@
       line-height: 24px;
       font-size: 16px;
       word-break: break-word;
+      white-space: pre-wrap;
     }
 
     &-component-body {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds `white-space: pre-wrap;` to the toast body so it displays newlines properly.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #66 

## Screenshots or GIFs (if appropriate):
<img width="346" alt="CleanShot 2020-04-23 at 22 49 59@2x" src="https://user-images.githubusercontent.com/19658460/80166636-cab9c080-85b4-11ea-91c9-b1999c7107a6.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/vue-toastification/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
