### PR TITLE
Fix toast width changing on transitioning out in certain layouts (#82)

### DIFF
--- a/src/components/VtTransition.vue
+++ b/src/components/VtTransition.vue
@@ -60,6 +60,7 @@ export default Vue.extend({
     setAbsolutePosition(el: HTMLElement) {
       el.style.left = el.offsetLeft + "px";
       el.style.top = el.offsetTop + "px";
+      el.style.width = el.offsetWidth + "px";
       el.style.position = "absolute";
     },
     cleanUpStyles(el: HTMLElement) {

--- a/tests/unit/components/VtTransition.spec.ts
+++ b/tests/unit/components/VtTransition.spec.ts
@@ -75,6 +75,7 @@ describe("VtTransition", () => {
     setAbsolutePosition(el);
     expect(el.style.left).toBe(el.offsetLeft + "px");
     expect(el.style.top).toBe(el.offsetTop + "px");
+    expect(el.style.width).toBe(el.offsetWidth + "px");
     expect(el.style.position).toBe("absolute");
   });
   it("afterEnter", () => {


### PR DESCRIPTION
Resolves #82

## Description
"Freeze" the width of the toast before switching position to `absolute` to avoid width changes in certain layouts where toast is set to use a fixed percentage width

## Related Issue
#82 

## Screenshots or GIFs (if appropriate):
![width-change-bug](https://user-images.githubusercontent.com/153197/81322588-83433200-9094-11ea-806f-15cccb9feec7.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/vue-toastification/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
