### PR TITLE
Use getComputedStyle to lock height/width during leave transition

### DIFF
--- a/src/components/VtTransition.vue
+++ b/src/components/VtTransition.vue
@@ -61,8 +61,8 @@ export default Vue.extend({
     setAbsolutePosition(el: HTMLElement) {
       el.style.left = el.offsetLeft + "px";
       el.style.top = el.offsetTop + "px";
-      el.style.width = el.getBoundingClientRect().width + "px";
-      el.style.height = el.getBoundingClientRect().height + "px";
+      el.style.width = getComputedStyle(el).width;
+      el.style.height = getComputedStyle(el).height;
       el.style.position = "absolute";
     },
     cleanUpStyles(el: HTMLElement) {

--- a/src/components/VtTransition.vue
+++ b/src/components/VtTransition.vue
@@ -61,7 +61,8 @@ export default Vue.extend({
     setAbsolutePosition(el: HTMLElement) {
       el.style.left = el.offsetLeft + "px";
       el.style.top = el.offsetTop + "px";
-      el.style.width = el.offsetWidth + "px";
+      el.style.width = el.getBoundingClientRect().width + "px";
+      el.style.height = el.getBoundingClientRect().height + "px";
       el.style.position = "absolute";
     },
     cleanUpStyles(el: HTMLElement) {

--- a/tests/unit/components/VtTransition.spec.ts
+++ b/tests/unit/components/VtTransition.spec.ts
@@ -89,8 +89,8 @@ describe("VtTransition", () => {
     setAbsolutePosition(el);
     expect(el.style.left).toBe(el.offsetLeft + "px");
     expect(el.style.top).toBe(el.offsetTop + "px");
-    expect(el.style.width).toBe(el.getBoundingClientRect().width + "px");
-    expect(el.style.height).toBe(el.getBoundingClientRect().height + "px");
+    expect(el.style.width).toBe(getComputedStyle(el).width);
+    expect(el.style.height).toBe(getComputedStyle(el).height);
     expect(el.style.position).toBe("absolute");
   });
   it("afterEnter", () => {

--- a/tests/unit/components/VtTransition.spec.ts
+++ b/tests/unit/components/VtTransition.spec.ts
@@ -89,7 +89,8 @@ describe("VtTransition", () => {
     setAbsolutePosition(el);
     expect(el.style.left).toBe(el.offsetLeft + "px");
     expect(el.style.top).toBe(el.offsetTop + "px");
-    expect(el.style.width).toBe(el.offsetWidth + "px");
+    expect(el.style.width).toBe(el.getBoundingClientRect().width + "px");
+    expect(el.style.height).toBe(el.getBoundingClientRect().height + "px");
     expect(el.style.position).toBe("absolute");
   });
   it("afterEnter", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`el.offsetWidth` and `el.offsetHeight` do no account for sub-pixel dimensions nor transforms, so the toasts' layout may be warped during leave transitions.

This PR fixes that by using `getComputedStyle` instead, which uses rendered values as opposed to viewport values.

Also, it begins to lock the toast's height as well as its width.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
resolves #87 

## Screenshots or GIFs (if appropriate):

Before:
![CleanShot 2020-05-29 at 13 24 49](https://user-images.githubusercontent.com/19658460/83282349-d6019c80-a1af-11ea-8b65-9c17353e22d2.gif)

After:
![CleanShot 2020-05-29 at 13 24 23](https://user-images.githubusercontent.com/19658460/83282358-d8fc8d00-a1af-11ea-86c0-aab7bf69df8d.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/vue-toastification/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
