### PR TITLE
Fixes safari's overflow + border-radius issues

### DIFF
--- a/src/scss/_toast.scss
+++ b/src/scss/_toast.scss
@@ -14,6 +14,10 @@
     min-width: $vt-toast-min-width;
     pointer-events: auto;
     overflow: hidden;
+    // overflow: hidden + border-radius does not work properly on Safari
+    // The following magic line fixes it
+    // https://stackoverflow.com/a/58283449
+    transform: translateZ(0);
     direction: ltr;
     &--rtl {
       direction: rtl;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Resolves a [known issue](https://stackoverflow.com/questions/49066011/overflow-hidden-with-border-radius-not-working-on-safari) with safari that causes the progress bar to visibly overflow the toast's body.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
resolves #93 

## Screenshots or GIFs (if appropriate):
Comparison available on the original issue #93 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/vue-toastification/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
