### PR TITLE
Normalize custom components

### DIFF
--- a/src/components/VtToastContainer.vue
+++ b/src/components/VtToastContainer.vue
@@ -23,7 +23,12 @@ import {
   ToastOptionsAndContent,
   ToastOptionsAndRequiredContent,
 } from "../types"
-import { removeElement, isUndefined, isFunction } from "../ts/utils"
+import {
+  removeElement,
+  isUndefined,
+  isFunction,
+  normalizeToastComponent,
+} from "../ts/utils"
 
 import Toast from "./VtToast.vue"
 import VtTransition from "./VtTransition.vue"
@@ -89,6 +94,7 @@ export default defineComponent({
       }
     },
     addToast(params: ToastOptionsAndRequiredContent) {
+      params.content = normalizeToastComponent(params.content)
       const props = Object.assign(
         {},
         this.defaults,

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -1,4 +1,4 @@
-import { Component, defineComponent } from "vue"
+import { Component, defineComponent, toRaw, unref } from "vue"
 import type {
   ToastComponent,
   ToastContent,
@@ -94,8 +94,19 @@ const getVueComponentFromObj = (obj: ToastContent): RenderableToastContent => {
       },
     })
   }
-  // Return the actual object if regular vue component
-  return obj
+  // Return regular string or raw object
+  return typeof obj === "string" ? obj : toRaw(unref(obj))
+}
+
+const normalizeToastComponent = (obj: ToastContent): ToastContent => {
+  if (typeof obj === "string") {
+    return obj
+  }
+  const props = hasProp(obj, "props") && isObject(obj.props) ? obj.props : {}
+  const listeners = (hasProp(obj, "listeners") && isObject(obj.listeners)
+    ? obj.listeners
+    : {}) as ToastComponent["listeners"]
+  return { component: getVueComponentFromObj(obj), props, listeners }
 }
 
 const isBrowser = () => typeof window !== "undefined"
@@ -109,6 +120,7 @@ export {
   isNonEmptyString,
   isToastContent,
   getVueComponentFromObj,
+  normalizeToastComponent,
   hasProp,
   isUndefined,
   isDOMRect,

--- a/tests/unit/components/VtCloseButton.spec.ts
+++ b/tests/unit/components/VtCloseButton.spec.ts
@@ -1,4 +1,5 @@
 import { mount } from "@vue/test-utils"
+import { markRaw } from "vue"
 import VtCloseButton from "../../../src/components/VtCloseButton.vue"
 import { VT_NAMESPACE } from "../../../src/ts/constants"
 import Simple from "../../utils/components/Simple.vue"
@@ -40,7 +41,7 @@ describe("VtCloseButton", () => {
   it("vue custom component", () => {
     const wrapper = mount(VtCloseButton, {
       props: {
-        component: Simple,
+        component: markRaw(Simple),
       },
     })
     expect(wrapper.findComponent(Simple).element).toBeTruthy()

--- a/tests/unit/components/VtIcon.spec.ts
+++ b/tests/unit/components/VtIcon.spec.ts
@@ -6,6 +6,7 @@ import VtInfoIcon from "../../../src/components/icons/VtInfoIcon.vue"
 import VtWarningIcon from "../../../src/components/icons/VtWarningIcon.vue"
 import VtErrorIcon from "../../../src/components/icons/VtErrorIcon.vue"
 import Simple from "../../utils/components/Simple.vue"
+import { markRaw } from "vue"
 
 describe("VtIcon", () => {
   describe("snapshots", () => {
@@ -103,7 +104,7 @@ describe("VtIcon", () => {
     it("renders custom component as icon", () => {
       const wrapper = mount(VtIcon, {
         props: {
-          customIcon: Simple,
+          customIcon: markRaw(Simple),
         },
       })
       expect(wrapper.findComponent(Simple).exists()).toBeTruthy()

--- a/tests/unit/components/VtToast.spec.ts
+++ b/tests/unit/components/VtToast.spec.ts
@@ -9,6 +9,7 @@ import { ToastOptionsAndContent } from "../../../src/types"
 import { VT_NAMESPACE, TYPE, POSITION, EVENTS } from "../../../src/ts/constants"
 import Simple from "../../utils/components/Simple.vue"
 import { EventBus } from "../../../src"
+import { normalizeToastComponent } from "../../../src/ts/utils"
 
 const setData = (
   wrapper: VueWrapper<ComponentPublicInstance>,
@@ -21,7 +22,7 @@ const mountToast = ({ id, content, ...props }: ToastOptionsAndContent = {}) =>
   mount(VtToast, {
     props: {
       id: id || 1,
-      content: content || "content",
+      content: normalizeToastComponent(content || "content"),
       eventBus: new EventBus(),
       ...props,
     },

--- a/tests/unit/ts/utils.spec.ts
+++ b/tests/unit/ts/utils.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable vue/one-component-per-file */
-import { defineComponent, h } from "vue"
+import { defineComponent, h, isProxy, isRef, reactive, ref } from "vue"
 import {
   getId,
   getX,
@@ -13,6 +13,7 @@ import {
   isUndefined,
   isDOMRect,
   isBrowser,
+  normalizeToastComponent,
 } from "../../../src/ts/utils"
 import Simple from "../../utils/components/Simple.vue"
 
@@ -158,6 +159,14 @@ describe("getVueComponentFromObj", () => {
     const component = defineComponent({})
     expect(getVueComponentFromObj(component)).toBe(component)
   })
+  it("get non reactive object", () => {
+    const component1 = reactive(defineComponent({}))
+    expect(isProxy(component1)).toBe(true)
+    expect(isProxy(getVueComponentFromObj(component1))).toBe(false)
+    const component2 = ref(defineComponent({}))
+    expect(isRef(component2)).toBe(true)
+    expect(isRef(getVueComponentFromObj(component2))).toBe(false)
+  })
   it("get functional component", () => {
     const component = () => h("div")
     expect(getVueComponentFromObj(component)).toBe(component)
@@ -174,6 +183,29 @@ describe("getVueComponentFromObj", () => {
   it("get toast component", () => {
     const component = { component: "my component string" }
     expect(getVueComponentFromObj(component)).toBe(component.component)
+  })
+})
+
+describe("normalizeToastComponent", () => {
+  it("normalizes regular string", () => {
+    const component = "my component string"
+    expect(normalizeToastComponent(component)).toBe(component)
+  })
+  it("normalizes shallow vue object", () => {
+    const component = Simple
+    expect(normalizeToastComponent(component)).toEqual({
+      component: getVueComponentFromObj(component),
+      props: {},
+      listeners: {},
+    })
+  })
+  it("normalizes composite vue object", () => {
+    const component = {
+      component: Simple,
+      props: { myProp: "prop" },
+      listeners: { myListener: () => ({}) },
+    }
+    expect(normalizeToastComponent(component)).toEqual(component)
   })
 })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Normalizes custom components before creating toasts so that:
- They are `unref`d
- They are `toRaw`d
- By default `props` and `listeners` are set to `{}`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #140 

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/vue-toastification/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
