### PR TITLE
Change analytics provider and enable EthicalAds on demo page

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "jest-serializer-vue": "^2.0.2",
     "lint-staged": "10.3.0",
     "nuxt": "^2.12.2",
+    "plausible-tracker": "^0.2.2",
     "prettier": "^2.0.5",
     "prismjs": "^1.20.0",
     "rollup": "^2.11.2",

--- a/public/App.vue
+++ b/public/App.vue
@@ -261,8 +261,18 @@
                   >Show toast!</v-btn
                 >
               </v-col>
-              <v-col cols="12" order="1" order-md="3" class="d-flex justify-center">
-                <div data-ea-publisher="maronato-github-iovue-toastification" data-ea-type="image" id="below-show-toast" data-ea-keywords="vue|frontend|design|javascript|typescript"></div>
+              <v-col
+                cols="12"
+                order="1"
+                order-md="3"
+                class="d-flex justify-center"
+              >
+                <div
+                  data-ea-publisher="maronato-github-iovue-toastification"
+                  data-ea-type="image"
+                  id="below-show-toast"
+                  data-ea-keywords="vue|frontend|design|javascript|typescript"
+                />
               </v-col>
             </v-row>
           </v-col>
@@ -279,7 +289,7 @@ import SimpleAction from "./components/SimpleAction.vue";
 import UpdateAction from "./components/UpdateAction.vue";
 import Events from "./components/Events.vue";
 import MyIconComponent from "./components/MyIconComponent.vue";
-import { trackEvent } from './plausible'
+import { trackEvent } from "./plausible";
 
 const altTextCode = `// Component.vue (style omitted)
 <template>

--- a/public/App.vue
+++ b/public/App.vue
@@ -231,23 +231,23 @@
           </v-col>
           <v-col order="2" cols="12" sm="8" md="4">
             <v-row>
-              <v-col order="1" order-md="0" cols="12">
+              <v-col order="2" order-md="0" cols="12">
                 <h1 class="display-1 font-weight-light">Preview the code</h1>
               </v-col>
-              <v-col order="3" order-md="3" cols="12">
+              <v-col order="3" order-md="4" cols="12">
                 <v-card class="pa-5">
                   <Prism language="javascript">{{ pluginCode }}</Prism>
                 </v-card>
               </v-col>
-              <v-col cols="12" order="2" order-md="1">
+              <v-col cols="12" order="3" order-md="2">
                 <v-card class="pa-5">
                   <Prism language="javascript">{{ toastCode }}</Prism>
                 </v-card>
               </v-col>
               <v-col
                 v-show="contentType !== 'text'"
-                order="3"
-                order-md="3"
+                order="4"
+                order-md="4"
                 cols="12"
               >
                 <v-card class="pa-5">
@@ -260,6 +260,9 @@
                 <v-btn color="primary" block large rounded @click="launch"
                   >Show toast!</v-btn
                 >
+              </v-col>
+              <v-col cols="12" order="1" order-md="3" class="d-flex justify-center">
+                <div data-ea-publisher="maronato-github-iovue-toastification" data-ea-type="image" id="below-show-toast" data-ea-keywords="vue|frontend|design"></div>
               </v-col>
             </v-row>
           </v-col>

--- a/public/App.vue
+++ b/public/App.vue
@@ -262,7 +262,7 @@
                 >
               </v-col>
               <v-col cols="12" order="1" order-md="3" class="d-flex justify-center">
-                <div data-ea-publisher="maronato-github-iovue-toastification" data-ea-type="image" id="below-show-toast" data-ea-keywords="vue|frontend|design"></div>
+                <div data-ea-publisher="maronato-github-iovue-toastification" data-ea-type="image" id="below-show-toast" data-ea-keywords="vue|frontend|design|javascript|typescript"></div>
               </v-col>
             </v-row>
           </v-col>

--- a/public/App.vue
+++ b/public/App.vue
@@ -270,12 +270,13 @@
 </template>
 
 <script>
+import Prism from "vue-prism-component";
 import AltText from "./components/AltText.vue";
 import SimpleAction from "./components/SimpleAction.vue";
 import UpdateAction from "./components/UpdateAction.vue";
 import Events from "./components/Events.vue";
 import MyIconComponent from "./components/MyIconComponent.vue";
-import Prism from "vue-prism-component";
+import { trackEvent } from './plausible'
 
 const altTextCode = `// Component.vue (style omitted)
 <template>
@@ -737,6 +738,7 @@ Vue.use(Toast, {
       if (options.timeout === 0) {
         options.timeout = false;
       }
+      trackEvent("show toast");
       this.$toast(content, {
         position: this.position,
         type: this.type,

--- a/public/index.html
+++ b/public/index.html
@@ -2,16 +2,6 @@
 <html lang="en">
 
 <head>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-150355609-1"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
-
-    gtag('config', 'UA-150355609-1');
-  </script>
-
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
     integrity="sha256-77qGXu2p8NpfcBpTjw4jsMeQnz0vyh74f5do0cWjQ/Q=" crossorigin="anonymous" />
   <link href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
   <title>Vue-Toastification</title>
 </head>
 
@@ -23,6 +24,9 @@
     integrity="sha256-HWJnMZHGx7U1jmNfxe4yaQedmpo/mtxWSIXvcJkLIf4=" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.17.1/plugins/autoloader/prism-autoloader.min.js"
     integrity="sha256-ht8ay6ZTPZfuixYB99I5oRpCLsCq7Do2LjEYLwbe+X8=" crossorigin="anonymous"></script>
+
+    <!-- Ethical ads -->
+  <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
 </body>
 
 </html>

--- a/public/index.js
+++ b/public/index.js
@@ -1,4 +1,5 @@
 import Vue from "vue";
+import { enableAutoPageviews } from "./plausible";
 import vuetify from "./vuetify";
 import App from "./App.vue";
 import Toast from "../src/index";
@@ -7,7 +8,9 @@ Vue.config.productionTip = false;
 
 Vue.use(Toast);
 
+enableAutoPageviews();
+
 new Vue({
   vuetify,
-  render: h => h(App)
+  render: (h) => h(App),
 }).$mount("#app");

--- a/public/plausible.js
+++ b/public/plausible.js
@@ -1,0 +1,6 @@
+import Plausible from "plausible-tracker";
+
+export const { enableAutoPageviews, trackEvent } = Plausible({
+  domain: "maronato.github.io/vue-toastification",
+  apiHost: "https://plausible.maronato.dev",
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9851,6 +9851,11 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
+plausible-tracker@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/plausible-tracker/-/plausible-tracker-0.2.2.tgz#bdbbad038816bac5b14b5b2216a48c5ddec59598"
+  integrity sha512-DxTszs9U2GAGg799TXL/w4uRRSoxcBt9v08zQgQVrs1SYlR0c+fPFXKuN1lv6RPTSIiQ7/UbXteR4GWz/bcLRA==
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes the demo page's analytics provider from Google Analytics to [Plausible Analytics](https://plausible.io/) and enable [EthicalAds](https://www.ethicalads.io/) on it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/vue-toastification/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
