### PR TITLE
Global toasts by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you are using Vue 2, check out [Vue Toastification v1](https://github.com/Mar
   - [Usage](#usage)
     - [Plugin registration](#plugin-registration)
     - [Creating toasts](#creating-toasts)
+    - [Using with Vuex or outside components](#using-with-vuex-or-outside-components)
     - [Positioning the Toast](#positioning-the-toast)
     - [Toast types](#toast-types)
     - [Setting the toast timeout](#setting-the-toast-timeout)
@@ -75,7 +76,6 @@ If you are using Vue 2, check out [Vue Toastification v1](https://github.com/Mar
 - [Updating from v1.x](#updating-from-v1x)
   - [Creating toasts](#creating-toasts-1)
   - [Deprecated options](#deprecated-options)
-  - [Nuxt and Vuex support](#nuxt-and-vuex-support)
 - [Acknowledgements](#acknowledgements)
 - [License](#license)
 
@@ -191,6 +191,34 @@ To create toasts, get a *toast interface* by calling `useToast` from within a co
     }
   }
 </script>
+```
+
+### Using with Vuex or outside components
+By default, Vue Toastification creates the plugin using a global event bus, so all you need to do to use it outside your components is to call `useToast()`.
+
+```js
+// store.js
+import { createStore } from 'vuex'
+import { useToast } from 'vue-toastification'
+
+const toast = useToast()
+
+const store = createStore({
+  state: {
+    count: 0
+  },
+  mutations: {
+    increment (state) {
+      state.count++
+    }
+  },
+  actions: {
+    increment (context) {
+      context.commit('increment')
+      toast.success("incremented!")
+    }
+  }
+})
 ```
 
 ### Positioning the Toast
@@ -994,9 +1022,6 @@ Aside from dropping Vue 2 support in favor of Vue 3, not much has changed betwee
 
 ## Deprecated options
 Due to some changes on Vue's transition system, `transitionDuration` has been deprecated. To change the duration of a transition, change or override the transition classes.
-
-## Nuxt and Vuex support
-Support for Nuxt and Vuex is still uncertain as their Vue 3-compatible versions have not been released yet.
 
 # Acknowledgements
 This project was heavily inspired by the beautiful [React Toastify](https://github.com/fkhadra/react-toastify) project and [other](https://github.com/shakee93/vue-toasted) [great](https://github.com/ankurk91/vue-toast-notification) Vue libraries.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Plugin, InjectionKey, provide, inject } from "vue"
+import { Plugin, InjectionKey, provide, inject, getCurrentInstance } from "vue"
 import { buildInterface } from "./ts/interface"
 import type { ToastInterface } from "./ts/interface"
 import { POSITION, TYPE } from "./ts/constants"
@@ -36,8 +36,10 @@ const toastInjectionKey: InjectionKey<ToastInterface> = Symbol(
   "VueToastification"
 )
 
-const VueToastificationPlugin: Plugin = (App, options?) => {
-  const inter = createToastInterface(options)
+const globalEventBus = new EventBus()
+
+const VueToastificationPlugin: Plugin = (App, options?: PluginOptions) => {
+  const inter = createToastInterface({ eventBus: globalEventBus, ...options })
   App.provide(toastInjectionKey, inter)
 }
 
@@ -50,8 +52,8 @@ const useToast = (eventBus?: EventBus) => {
   if (eventBus) {
     return ownExports.createToastInterface(eventBus)
   }
-  const toast = inject(toastInjectionKey)
-  return toast ? toast : ownExports.createToastInterface(new EventBus())
+  const toast = getCurrentInstance() ? inject(toastInjectionKey) : undefined
+  return toast ? toast : ownExports.createToastInterface(globalEventBus)
 }
 
 export default VueToastificationPlugin
@@ -70,4 +72,6 @@ export {
   provideToast,
   // Classes
   EventBus,
+  // Instances
+  globalEventBus,
 }

--- a/tests/unit/index.spec.ts
+++ b/tests/unit/index.spec.ts
@@ -208,6 +208,27 @@ describe("useToast", () => {
     expect(createToastInterfaceSpy).toHaveBeenCalledTimes(1)
   })
 
+  it("Works outside of components", async () => {
+    const useToastSpy = jest.spyOn(index, "useToast")
+    const injectSpy = jest.spyOn(vue, "inject")
+    const createToastInterfaceSpy = jest.spyOn(index, "createToastInterface")
+    const getCurrentInstanceSpy = jest.spyOn(vue, "getCurrentInstance")
+
+    expect(useToastSpy).not.toHaveBeenCalled()
+    expect(injectSpy).not.toHaveBeenCalled()
+    expect(createToastInterfaceSpy).not.toHaveBeenCalled()
+    expect(getCurrentInstanceSpy).not.toHaveBeenCalled()
+
+    const inter = index.useToast()
+
+    expect(useToastSpy).toHaveBeenCalledTimes(1)
+    expect(getCurrentInstanceSpy).toHaveBeenCalledTimes(1)
+    expect(getCurrentInstanceSpy).toHaveReturnedWith(null)
+    expect(injectSpy).not.toHaveBeenCalled()
+    expect(createToastInterfaceSpy).toHaveBeenCalledTimes(1)
+    expect(createToastInterfaceSpy).toHaveBeenCalledWith(index.globalEventBus)
+  })
+
   it("creates from eventBus", () => {
     const useToastSpy = jest.spyOn(index, "useToast")
     const injectSpy = jest.spyOn(vue, "inject")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In light of issues such as #146 and #134, Vue Toastification should attempt to be global-first, while allowing more complex usages with additional setup.

This means that you can now use `useToast()` natively outside of components.

First, you need to install the plugin as per usual:
```js
import { createApp } from "vue";
import Toast from "vue-toastification";
import "vue-toastification/dist/index.css";

const app = createApp(...);
app.use(Toast);
```

Then you can call `useToast` anywhere:
```js
// From inside components
import { useToast } from "vue-toastification";

export default {
  setup() {
    const toast = useToast();
  }
}
```

And in other files such as vuex stores:
```js
// store.js
import { createStore } from 'vuex'
import { useToast } from 'vue-toastification'

const toast = useToast()

const store = createStore({
  state: {
    count: 0
  },
  mutations: {
    increment (state) {
      state.count++
    }
  },
  actions: {
    increment (context) {
      context.commit('increment')
      toast.success("incremented!")
    }
  }
})
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/vue-toastification/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
