### PR TITLE
Fixed incorrect initial setting of hideProgressBar option

### DIFF
--- a/public/App.vue
+++ b/public/App.vue
@@ -714,7 +714,7 @@ export default {
   draggable: ${this.options.draggable},
   draggablePercent: ${this.options.draggablePercent / 100},
   showCloseButtonOnHover: ${this.options.showCloseButtonOnHover},
-  hideProgressBar: ${!this.options.hideProgressBar},
+  hideProgressBar: ${this.options.hideProgressBar},
   closeButton: ${
     this.options.closeButton ? `"${this.options.closeButton}"` : "false"
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The toggle button of Hide progress bar is not align with the data shown in Preview the code

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Maronato/vue-toastification/issues/251

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Fixed initial setting of hideProgressBar option 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/Maronato/vue-toastification/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
