### PR TITLE
Fix: Sass Slash as Division #243

### DIFF
--- a/src/scss/_toastContainer.scss
+++ b/src/scss/_toastContainer.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 .#{$vt-namespace}__container {
   z-index: $vt-z-index;
   position: fixed;
@@ -51,7 +52,7 @@
     &.top-center,
     &.bottom-center {
       left: 50%;
-      margin-left: -($vt-toast-max-width / 2);
+      margin-left: -(math.div($vt-toast-max-width, 2));
       .#{$vt-namespace}__toast {
         margin-left: auto;
         margin-right: auto;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Fixed the deprecated warning: Using / for division is deprecated and will be removed in Dart Sass 2.0.0
Followed the documentation here: https://sass-lang.com/documentation/breaking-changes/slash-div

## Related Issue
Fixes #243

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/vue-toastification/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
Only one test failed which has nothing to do with the changes this PR made.