### PR TITLE
Fix Nuxt Composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Wanna try it out? Check out the [live demo](https://maronato.github.io/vue-toast
   - [Usage](#usage)
     - [Plugin registration](#plugin-registration)
     - [Nuxt registration](#nuxt-registration)
+      - [Nuxt and Composition API](#nuxt-and-composition-api)
       - [Injecting the Toast CSS](#injecting-the-toast-css)
     - [Composition API registration](#composition-api-registration)
     - [Generic registration](#generic-registration)
@@ -204,6 +205,22 @@ If you are using Typescript with Nuxt, you may need to add `"vue-toastification/
 }
 ```
 
+#### Nuxt and Composition API
+Since Vue Toastification is auto installed with nuxt, we need not provide it a second time.
+
+To access your `$toast` instance from within `setup()`, import from `vue-toastification/composition/nuxt` like so:
+```ts
+// MyComponent.vue
+
+// Import from vue-toastification/composition/nuxt, not vue-toastification/composition
+import { useToast } from "vue-toastification/composition/nuxt";
+
+// Then, in the setup method
+  setup() {
+    const toast = useToast()
+    // Use it like you would use this.$toast
+  }
+```
 
 #### Injecting the Toast CSS
 By default, when you register the module within Nuxt it automatically injects the CSS required to display the toasts using the default `vue-toastification/dist/index.css` file.

--- a/composition/index.d.ts
+++ b/composition/index.d.ts
@@ -1,11 +1,11 @@
-import _Vue from "vue";
-import { VueConstructor } from "vue/types/vue";
-import { PluginOptions } from "vue-toastification/dist/types/src/types";
-import ToastInterface from "vue-toastification/dist/types/src/ts/interface";
+import _Vue from "vue"
+import type { VueConstructor } from "vue/types/vue"
+import type { PluginOptions } from "../src/types"
+import type ToastInterface from "../src/ts/interface"
 
-declare let provideToast: (options?: PluginOptions) => void;
+declare let provideToast: (options?: PluginOptions) => void
 declare let useToast: (
   eventBus?: InstanceType<VueConstructor>
-) => ReturnType<typeof ToastInterface>;
+) => ReturnType<typeof ToastInterface>
 
-export { provideToast, useToast };
+export { provideToast, useToast }

--- a/composition/nuxt/index.d.ts
+++ b/composition/nuxt/index.d.ts
@@ -1,0 +1,5 @@
+import type ToastInterface from "../../src/ts/interface";
+
+declare let useToast: () => ReturnType<typeof ToastInterface>;
+
+export { useToast };

--- a/composition/nuxt/index.js
+++ b/composition/nuxt/index.js
@@ -1,0 +1,5 @@
+const { useContext } = require("@nuxtjs/composition-api"); // eslint-disable-line @typescript-eslint/no-var-requires
+
+export const useToast = () => useContext().app.$toast;
+
+module.exports = { useToast };

--- a/nuxt/index.d.ts
+++ b/nuxt/index.d.ts
@@ -1,2 +1,4 @@
-declare const toastModule: import("@nuxt/types").Module<import("../src/types/index").NuxtModuleOptions>;
+declare const toastModule: import("@nuxt/types").Module<
+  import("../src/types/index").NuxtModuleOptions
+>;
 export = toastModule;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently it is not possible to use the built-in composition library with nuxt because the provide scope is not shared by nuxt's instance.
This PR creates a new export `useToast` from `"vue-toastification/composition/nuxt"`:
```ts
// MyComponent.vue
// Import from vue-toastification/composition/nuxt, not vue-toastification/composition
import { useToast } from "vue-toastification/composition/nuxt";
// Then, in the setup method
  setup() {
    const toast = useToast()
    // Use it like you would use this.$toast
  }
```

It also fixes typing issues mentioned in #180 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes  #180 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ x New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/vue-toastification/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
