### PR TITLE
Conditional border radius with viewport width

### DIFF
--- a/src/scss/_toast.scss
+++ b/src/scss/_toast.scss
@@ -6,7 +6,8 @@
   box-sizing: border-box;
   margin-bottom: 1rem;
   padding: 22px 24px;
-  border-radius: 8px;
+  // https://css-tricks.com/conditional-border-radius-in-css/
+  border-radius: max(0px, min(8px, calc((100vw - 4px - 100%) * 9999)));
   box-shadow: 0 1px 10px 0 rgba(0, 0, 0, 0.1), 0 2px 15px 0 rgba(0, 0, 0, 0.05);
   justify-content: space-between;
   font-family: $vt-font-family;
@@ -45,7 +46,6 @@
   }
 
   @media #{$vt-mobile} {
-    border-radius: 0px;
     margin-bottom: 0.5rem;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We only have to reset border-radius when toast container width equals to viewport width.

## Description
See [see article](https://css-tricks.com/conditional-border-radius-in-css/) for more information
