### PR TITLE
Handle Toast event logic as composable hooks

### DIFF
--- a/src/components/VtProgressBar.vue
+++ b/src/components/VtProgressBar.vue
@@ -13,9 +13,7 @@ export default defineComponent({
 
   props: PROPS.PROGRESS_BAR,
 
-  // TODO: The typescript compiler is not playing nice with emit types
-  // Rollback this change once ts is able to infer emit types
-  // emits: ["close-toast"],
+  emits: ["close-toast"],
 
   data() {
     return {
@@ -58,8 +56,6 @@ export default defineComponent({
 
   methods: {
     animationEnded() {
-      // See TODO on line 16
-      // eslint-disable-next-line vue/require-explicit-emits
       this.$emit("close-toast")
     },
   },

--- a/src/components/VtToast.vue
+++ b/src/components/VtToast.vue
@@ -48,6 +48,7 @@ import ProgressBar from "./VtProgressBar.vue"
 import CloseButton from "./VtCloseButton.vue"
 import Icon from "./VtIcon.vue"
 import { useHoverable } from "../ts/composables/useHoverable"
+import { useFocusable } from "../ts/composables/useFocusable"
 
 export default defineComponent({
   name: "VtToast",
@@ -61,11 +62,12 @@ export default defineComponent({
     const el = ref<HTMLElement>()
 
     const { hovering } = useHoverable(el, props)
+    const { focused } = useFocusable(el, props)
 
     const isRunning = ref(true)
 
-    watch(hovering, () => {
-      isRunning.value = !hovering.value
+    watch([hovering, focused], () => {
+      isRunning.value = !hovering.value && focused.value
     })
 
     return {
@@ -152,16 +154,10 @@ export default defineComponent({
     if (this.draggable) {
       this.draggableSetup()
     }
-    if (this.pauseOnFocusLoss) {
-      this.focusSetup()
-    }
   },
   beforeUnmount() {
     if (this.draggable) {
       this.draggableCleanup()
-    }
-    if (this.pauseOnFocusLoss) {
-      this.focusCleanup()
     }
   },
 
@@ -183,21 +179,6 @@ export default defineComponent({
     },
     timeoutHandler() {
       this.closeToast()
-    },
-    focusPause() {
-      this.isRunning = false
-    },
-    focusPlay() {
-      this.isRunning = true
-    },
-
-    focusSetup() {
-      addEventListener("blur", this.focusPause)
-      addEventListener("focus", this.focusPlay)
-    },
-    focusCleanup() {
-      removeEventListener("blur", this.focusPause)
-      removeEventListener("focus", this.focusPlay)
     },
 
     draggableSetup() {

--- a/src/components/VtToast.vue
+++ b/src/components/VtToast.vue
@@ -31,7 +31,7 @@
       :is-running="isRunning"
       :hide-progress-bar="hideProgressBar"
       :timeout="timeout"
-      @closeToast="timeoutHandler"
+      @close-toast="timeoutHandler"
     />
   </div>
 </template>

--- a/src/components/VtToast.vue
+++ b/src/components/VtToast.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="el" :class="classes" :style="draggableStyle" @click="clickHandler">
+  <div ref="el" :class="classes" @click="clickHandler">
     <Icon v-if="icon" :custom-icon="icon" :type="type" />
     <div :role="accessibility.toastRole || 'alert'" :class="bodyClasses">
       <template v-if="typeof content === 'string'">{{ content }}</template>
@@ -7,8 +7,8 @@
         :is="getVueComponentFromObj(content)"
         v-else
         :toast-id="id"
-        v-bind="hasProp(content, 'props') ? content.props : {}"
-        v-on="hasProp(content, 'listeners') ? content.listeners : {}"
+        v-bind="getProp(content, 'props', {})"
+        v-on="getProp(content, 'listeners', {})"
         @closeToast="closeToast"
       />
     </div>
@@ -25,30 +25,24 @@
       :is-running="isRunning"
       :hide-progress-bar="hideProgressBar"
       :timeout="timeout"
-      @close-toast="timeoutHandler"
+      @close-toast="closeToast"
     />
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch } from "vue"
+import { computed, defineComponent, nextTick, ref, watch } from "vue"
 
 import { EVENTS, VT_NAMESPACE } from "../ts/constants"
 import PROPS from "../ts/propValidators"
-import {
-  getVueComponentFromObj,
-  isString,
-  getX,
-  getY,
-  isDOMRect,
-  hasProp,
-} from "../ts/utils"
+import { getVueComponentFromObj, isString, getProp } from "../ts/utils"
 
 import ProgressBar from "./VtProgressBar.vue"
 import CloseButton from "./VtCloseButton.vue"
 import Icon from "./VtIcon.vue"
 import { useHoverable } from "../ts/composables/useHoverable"
 import { useFocusable } from "../ts/composables/useFocusable"
+import { useDraggable } from "../ts/composables/useDraggable"
 
 export default defineComponent({
   name: "VtToast",
@@ -63,184 +57,64 @@ export default defineComponent({
 
     const { hovering } = useHoverable(el, props)
     const { focused } = useFocusable(el, props)
+    const { beingDragged, dragComplete } = useDraggable(el, props)
 
-    const isRunning = ref(true)
+    const isRunning = computed(
+      () => !hovering.value && focused.value && !beingDragged.value
+    )
 
-    watch([hovering, focused], () => {
-      isRunning.value = !hovering.value && focused.value
+    const closeToast = () => {
+      props.eventBus.emit(EVENTS.DISMISS, props.id)
+    }
+
+    const clickHandler = () => {
+      if (!beingDragged.value) {
+        if (props.onClick) {
+          props.onClick(closeToast)
+        }
+        if (props.closeOnClick) {
+          closeToast()
+        }
+      }
+    }
+
+    watch(dragComplete, v => {
+      if (v) {
+        nextTick(() => closeToast())
+      }
     })
-
-    return {
-      isRunning,
-      el,
-    }
-  },
-
-  data() {
-    const data: {
-      dragRect: DOMRect | Record<string, unknown>
-      disableTransitions: boolean
-      beingDragged: boolean
-      dragStart: number
-      dragPos: { x: number; y: number }
-    } = {
-      disableTransitions: false,
-
-      beingDragged: false,
-      dragStart: 0,
-      dragPos: { x: 0, y: 0 },
-      dragRect: {},
-    }
-    return data
-  },
-
-  computed: {
-    classes(): string[] {
+    const classes = computed(() => {
       const classes = [
         `${VT_NAMESPACE}__toast`,
-        `${VT_NAMESPACE}__toast--${this.type}`,
-        `${this.position}`,
-      ].concat(this.toastClassName)
-      if (this.disableTransitions) {
+        `${VT_NAMESPACE}__toast--${props.type}`,
+        `${props.position}`,
+      ].concat(props.toastClassName)
+      if (dragComplete.value) {
         classes.push("disable-transition")
       }
-      if (this.rtl) {
+      if (props.rtl) {
         classes.push(`${VT_NAMESPACE}__toast--rtl`)
       }
       return classes
-    },
-    bodyClasses(): string[] {
-      const classes = [
+    })
+    const bodyClasses = computed(() =>
+      [
         `${VT_NAMESPACE}__toast-${
-          isString(this.content) ? "body" : "component-body"
+          isString(props.content) ? "body" : "component-body"
         }`,
-      ].concat(this.bodyClassName)
-      return classes
-    },
-    draggableStyle(): {
-      transition?: string
-      opacity?: number
-      transform?: string
-    } {
-      if (this.dragStart === this.dragPos.x) {
-        return {}
-      } else if (this.beingDragged) {
-        return {
-          transform: `translateX(${this.dragDelta}px)`,
-          opacity: 1 - Math.abs(this.dragDelta / this.removalDistance),
-        }
-      } else {
-        return {
-          transition: "transform 0.2s, opacity 0.2s",
-          transform: "translateX(0)",
-          opacity: 1,
-        }
-      }
-    },
-    dragDelta(): number {
-      return this.beingDragged ? this.dragPos.x - this.dragStart : 0
-    },
-    removalDistance(): number {
-      if (isDOMRect(this.dragRect)) {
-        return (
-          (this.dragRect.right - this.dragRect.left) * this.draggablePercent
-        )
-      }
-      return 0
-    },
-  },
+      ].concat(props.bodyClassName)
+    )
 
-  mounted() {
-    if (this.draggable) {
-      this.draggableSetup()
+    return {
+      isRunning,
+      classes,
+      bodyClasses,
+      clickHandler,
+      getVueComponentFromObj,
+      closeToast,
+      getProp,
+      el,
     }
-  },
-  beforeUnmount() {
-    if (this.draggable) {
-      this.draggableCleanup()
-    }
-  },
-
-  methods: {
-    hasProp,
-    getVueComponentFromObj,
-    closeToast() {
-      this.eventBus.emit(EVENTS.DISMISS, this.id)
-    },
-    clickHandler() {
-      if (this.onClick) {
-        this.onClick(this.closeToast)
-      }
-      if (this.closeOnClick) {
-        if (!this.beingDragged || this.dragStart === this.dragPos.x) {
-          this.closeToast()
-        }
-      }
-    },
-    timeoutHandler() {
-      this.closeToast()
-    },
-
-    draggableSetup() {
-      const element = this.$el as HTMLElement
-      element.addEventListener("touchstart", this.onDragStart, {
-        passive: true,
-      })
-      element.addEventListener("mousedown", this.onDragStart)
-      addEventListener("touchmove", this.onDragMove, { passive: false })
-      addEventListener("mousemove", this.onDragMove)
-      addEventListener("touchend", this.onDragEnd)
-      addEventListener("mouseup", this.onDragEnd)
-    },
-    draggableCleanup() {
-      const element = this.$el as HTMLElement
-      element.removeEventListener("touchstart", this.onDragStart)
-      element.removeEventListener("mousedown", this.onDragStart)
-      removeEventListener("touchmove", this.onDragMove)
-      removeEventListener("mousemove", this.onDragMove)
-      removeEventListener("touchend", this.onDragEnd)
-      removeEventListener("mouseup", this.onDragEnd)
-    },
-
-    onDragStart(event: TouchEvent | MouseEvent) {
-      this.beingDragged = true
-      this.dragPos = { x: getX(event), y: getY(event) }
-      this.dragStart = getX(event)
-      this.dragRect = this.$el.getBoundingClientRect()
-    },
-    onDragMove(event: TouchEvent | MouseEvent) {
-      if (this.beingDragged) {
-        event.preventDefault()
-        if (this.isRunning) {
-          this.isRunning = false
-        }
-        this.dragPos = { x: getX(event), y: getY(event) }
-      }
-    },
-    onDragEnd() {
-      if (this.beingDragged) {
-        if (Math.abs(this.dragDelta) >= this.removalDistance) {
-          this.disableTransitions = true
-          this.$nextTick(() => this.closeToast())
-        } else {
-          setTimeout(() => {
-            this.beingDragged = false
-            if (
-              isDOMRect(this.dragRect) &&
-              this.pauseOnHover &&
-              this.dragRect.bottom >= this.dragPos.y &&
-              this.dragPos.y >= this.dragRect.top &&
-              this.dragRect.left <= this.dragPos.x &&
-              this.dragPos.x <= this.dragRect.right
-            ) {
-              this.isRunning = false
-            } else {
-              this.isRunning = true
-            }
-          })
-        }
-      }
-    },
   },
 })
 </script>

--- a/src/components/VtTransition.vue
+++ b/src/components/VtTransition.vue
@@ -2,11 +2,11 @@
   <transition-group
     tag="div"
     :enter-active-class="
-      transition.enter ? transition.enter : `${transition}-enter-active`
+      getProp(transition, 'enter', `${transition}-enter-active`)
     "
-    :move-class="transition.move ? transition.move : `${transition}-move`"
+    :move-class="getProp(transition, 'move', `${transition}-move`)"
     :leave-active-class="
-      transition.leave ? transition.leave : `${transition}-leave-active`
+      getProp(transition, 'leave', `${transition}-leave-active`)
     "
     @leave="leave"
   >
@@ -16,7 +16,7 @@
 <script lang="ts">
 // Transition methods taken from https://github.com/BinarCode/vue2-transitions
 import { defineComponent } from "vue"
-import { hasProp } from "../ts/utils"
+import { getProp } from "../ts/utils"
 import PROPS from "../ts/propValidators"
 
 export default defineComponent({
@@ -26,7 +26,7 @@ export default defineComponent({
   emits: ["leave"],
 
   methods: {
-    hasProp,
+    getProp,
     leave(el: Element) {
       if (el instanceof HTMLElement) {
         el.style.left = el.offsetLeft + "px"

--- a/src/ts/composables/useDraggable.ts
+++ b/src/ts/composables/useDraggable.ts
@@ -1,0 +1,113 @@
+import {
+  toRefs,
+  ref,
+  Ref,
+  onMounted,
+  onBeforeUnmount,
+  computed,
+  watch,
+} from "vue"
+import { ToastOptions } from "../../types"
+import { isDOMRect, getX, getY } from "../utils"
+
+export const useDraggable = (
+  el: Ref<HTMLElement | undefined>,
+  props: Required<Pick<ToastOptions, "draggablePercent" | "draggable">>
+) => {
+  // Extract used props
+  const { draggablePercent, draggable } = toRefs(props)
+
+  // Define state
+  const dragRect = computed(() =>
+    el.value ? el.value.getBoundingClientRect() : undefined
+  )
+  const dragStarted = ref(false)
+  const beingDragged = ref(false)
+  const dragPos = ref({ x: 0, y: 0 })
+  const dragStart = ref(0)
+  const dragDelta = computed(() =>
+    beingDragged.value ? dragPos.value.x - dragStart.value : 0
+  )
+  const dragComplete = ref(false)
+
+  // Computed state
+  const removalDistance = computed(() =>
+    isDOMRect(dragRect.value)
+      ? (dragRect.value.right - dragRect.value.left) * draggablePercent.value
+      : 0
+  )
+
+  // Update style to match drag
+  watch(
+    [el, dragStart, dragPos, dragDelta, removalDistance, beingDragged],
+    () => {
+      /* istanbul ignore else  */
+      if (el.value) {
+        el.value.style.transform = "translateX(0px)"
+        el.value.style.opacity = "1"
+        if (dragStart.value === dragPos.value.x) {
+          el.value.style.transition = ""
+        } else if (beingDragged.value) {
+          el.value.style.transform = `translateX(${dragDelta.value}px)`
+          el.value.style.opacity = `${
+            1 - Math.abs(dragDelta.value / removalDistance.value)
+          }`
+        } else {
+          el.value.style.transition = "transform 0.2s, opacity 0.2s"
+        }
+      }
+    }
+  )
+
+  // Define handlers
+  const onDragStart = (event: TouchEvent | MouseEvent) => {
+    dragStarted.value = true
+    dragPos.value = { x: getX(event), y: getY(event) }
+    dragStart.value = dragPos.value.x
+  }
+  const onDragMove = (event: TouchEvent | MouseEvent) => {
+    if (dragStarted.value) {
+      beingDragged.value = true
+      event.preventDefault()
+      dragPos.value = { x: getX(event), y: getY(event) }
+    }
+  }
+  const onDragEnd = () => {
+    dragStarted.value = false
+    if (beingDragged.value) {
+      if (Math.abs(dragDelta.value) >= removalDistance.value) {
+        dragComplete.value = true
+      } else {
+        setTimeout(() => {
+          beingDragged.value = false
+        })
+      }
+    }
+  }
+
+  onMounted(() => {
+    if (draggable.value && el.value) {
+      el.value.addEventListener("touchstart", onDragStart, {
+        passive: true,
+      })
+      el.value.addEventListener("mousedown", onDragStart)
+      addEventListener("touchmove", onDragMove, { passive: false })
+      addEventListener("mousemove", onDragMove)
+      addEventListener("touchend", onDragEnd)
+      addEventListener("mouseup", onDragEnd)
+    }
+  })
+  onBeforeUnmount(() => {
+    /* istanbul ignore else  */
+    if (draggable.value && el.value) {
+      el.value.removeEventListener("touchstart", onDragStart)
+      el.value.removeEventListener("mousedown", onDragStart)
+      removeEventListener("touchmove", onDragMove)
+      removeEventListener("mousemove", onDragMove)
+      removeEventListener("touchend", onDragEnd)
+      removeEventListener("mouseup", onDragEnd)
+    }
+  })
+
+  return { dragComplete, beingDragged }
+}

--- a/src/ts/composables/useFocusable.ts
+++ b/src/ts/composables/useFocusable.ts
@@ -1,0 +1,26 @@
+import { toRefs, ref, Ref, onMounted, onBeforeUnmount } from "vue"
+import { ToastOptions } from "../../types"
+
+export const useFocusable = (
+  el: Ref<HTMLElement | undefined>,
+  props: Required<Pick<ToastOptions, "pauseOnFocusLoss">>
+) => {
+  const { pauseOnFocusLoss } = toRefs(props)
+  const focused = ref(true)
+  const onFocus = () => (focused.value = true)
+  const onBlur = () => (focused.value = false)
+  onMounted(() => {
+    if (el.value && pauseOnFocusLoss.value) {
+      addEventListener("blur", onBlur)
+      addEventListener("focus", onFocus)
+    }
+  })
+  onBeforeUnmount(() => {
+    if (el.value && pauseOnFocusLoss.value) {
+      removeEventListener("blur", onBlur)
+      removeEventListener("focus", onFocus)
+    }
+  })
+
+  return { focused }
+}

--- a/src/ts/composables/useHoverable.ts
+++ b/src/ts/composables/useHoverable.ts
@@ -1,0 +1,27 @@
+import { toRefs, ref, Ref, onMounted, onBeforeUnmount } from "vue"
+import { ToastOptions } from "../../types"
+
+export const useHoverable = (
+  el: Ref<HTMLElement | undefined>,
+  props: Required<Pick<ToastOptions, "pauseOnHover">>
+) => {
+  const { pauseOnHover } = toRefs(props)
+  const hovering = ref(false)
+
+  const onEnter = () => (hovering.value = true)
+  const onLeave = () => (hovering.value = false)
+  onMounted(() => {
+    if (el.value && pauseOnHover.value) {
+      el.value.addEventListener("mouseenter", onEnter)
+      el.value.addEventListener("mouseleave", onLeave)
+    }
+  })
+  onBeforeUnmount(() => {
+    if (el.value && pauseOnHover.value) {
+      el.value.removeEventListener("mouseenter", onEnter)
+      el.value.removeEventListener("mouseleave", onLeave)
+    }
+  })
+
+  return { hovering }
+}

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -60,6 +60,15 @@ const hasProp = <O, K extends PropertyKey>(
 ): obj is O & { [key in K]: unknown } =>
   (isObject(obj) || isFunction(obj)) && propKey in obj
 
+const getProp = <O, K extends PropertyKey, D>(
+  obj: O,
+  propKey: K,
+  fallback: D
+): K extends keyof O ? O[K] : D =>
+  (hasProp(obj, propKey) ? obj[propKey] : fallback) as K extends keyof O
+    ? O[K]
+    : D
+
 /**
  * ID generator
  */
@@ -129,4 +138,5 @@ export {
   isDOMRect,
   isFunction,
   isBrowser,
+  getProp,
 }

--- a/tests/unit/components/VtToast.spec.ts
+++ b/tests/unit/components/VtToast.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentPublicInstance } from "vue"
+import { ComponentPublicInstance, nextTick } from "vue"
 import { mount, VueWrapper, DOMWrapper } from "@vue/test-utils"
 import merge from "lodash.merge"
 import VtToast from "../../../src/components/VtToast.vue"
@@ -351,36 +351,6 @@ describe("VtToast", () => {
 
       expect(spyOnDraggableSetup).not.toHaveBeenCalled()
     })
-    it("calls focusSetup if this.pauseOnFocusLoss is true", () => {
-      const spy = jest.spyOn(VtToast.methods, "focusSetup")
-
-      expect(spy).not.toHaveBeenCalled()
-
-      mount(VtToast, {
-        props: {
-          pauseOnFocusLoss: true,
-          id: 1,
-          content: "content",
-        },
-      })
-
-      expect(spy).toHaveBeenCalled()
-    })
-    it("does not call focusSetup if this.pauseOnFocusLoss is false", () => {
-      const spy = jest.spyOn(VtToast.methods, "focusSetup")
-
-      expect(spy).not.toHaveBeenCalled()
-
-      mount(VtToast, {
-        props: {
-          pauseOnFocusLoss: false,
-          id: 1,
-          content: "content",
-        },
-      })
-
-      expect(spy).not.toHaveBeenCalled()
-    })
   })
   describe("beforeunmount", () => {
     it("calls draggableCleanup if this.draggable is true", async () => {
@@ -404,28 +374,6 @@ describe("VtToast", () => {
       expect(spyOnDraggableCleanup).not.toHaveBeenCalled()
       wrapper.unmount()
       expect(spyOnDraggableCleanup).not.toHaveBeenCalled()
-    })
-    it("calls focusCleanup if this.pauseOnFocusLoss is true", () => {
-      const wrapper = mountToast({ pauseOnFocusLoss: true })
-      const vm = wrapper.vm as unknown as {
-        focusCleanup(): void
-      }
-
-      const spyOnfocusCleanup = (vm.focusCleanup = jest.fn())
-      expect(spyOnfocusCleanup).not.toHaveBeenCalled()
-      wrapper.unmount()
-      expect(spyOnfocusCleanup).toHaveBeenCalled()
-    })
-    it("does not call focusCleanup if this.pauseOnFocusLoss is false", () => {
-      const wrapper = mountToast({ pauseOnFocusLoss: false })
-      const vm = wrapper.vm as unknown as {
-        focusCleanup(): void
-      }
-
-      const spyOnfocusCleanup = (vm.focusCleanup = jest.fn())
-      expect(spyOnfocusCleanup).not.toHaveBeenCalled()
-      wrapper.unmount()
-      expect(spyOnfocusCleanup).not.toHaveBeenCalled()
     })
   })
   describe("closeToast", () => {
@@ -529,46 +477,29 @@ describe("VtToast", () => {
       expect(vm.isRunning).toBe(true)
     })
   })
-  describe("focusPause", () => {
-    it("pauses on blur if pauseOnFocusLoss", () => {
+  describe("focus", () => {
+    it("pauses/resumes if pauseOnFocusLoss", async () => {
       const wrapper = mountToast({ pauseOnFocusLoss: true })
       const vm = wrapper.vm as unknown as {
         isRunning: boolean
       }
       expect(vm.isRunning).toBe(true)
       window.dispatchEvent(new window.FocusEvent("blur"))
+      await nextTick()
       expect(vm.isRunning).toBe(false)
+      window.dispatchEvent(new window.FocusEvent("focus"))
+      await nextTick()
+      expect(vm.isRunning).toBe(true)
     })
-    it("does not pause on blur if not pauseOnFocusLoss", () => {
+    it("does not pause/resume if not pauseOnFocusLoss", async () => {
       const wrapper = mountToast({ pauseOnFocusLoss: false })
       const vm = wrapper.vm as unknown as {
         isRunning: boolean
       }
       expect(vm.isRunning).toBe(true)
       window.dispatchEvent(new window.FocusEvent("blur"))
+      await nextTick()
       expect(vm.isRunning).toBe(true)
-    })
-  })
-  describe("focusPlay", () => {
-    it("resume on focus if pauseOnFocusLoss", () => {
-      const wrapper = mountToast({ pauseOnFocusLoss: true })
-      setData(wrapper, { isRunning: false })
-      const vm = wrapper.vm as unknown as {
-        isRunning: boolean
-      }
-      expect(vm.isRunning).toBe(false)
-      window.dispatchEvent(new window.FocusEvent("focus"))
-      expect(vm.isRunning).toBe(true)
-    })
-    it("does not resume on focus if not pauseOnFocusLoss", () => {
-      const wrapper = mountToast({ pauseOnFocusLoss: false })
-      setData(wrapper, { isRunning: false })
-      const vm = wrapper.vm as unknown as {
-        isRunning: boolean
-      }
-      expect(vm.isRunning).toBe(false)
-      window.dispatchEvent(new window.FocusEvent("focus"))
-      expect(vm.isRunning).toBe(false)
     })
   })
   describe("onDragStart", () => {

--- a/tests/unit/components/VtToast.spec.ts
+++ b/tests/unit/components/VtToast.spec.ts
@@ -1,5 +1,5 @@
-import { ComponentPublicInstance, nextTick } from "vue"
-import { mount, VueWrapper, DOMWrapper } from "@vue/test-utils"
+import { ComponentPublicInstance, nextTick, ref } from "vue"
+import { mount, VueWrapper } from "@vue/test-utils"
 import merge from "lodash.merge"
 import VtToast from "../../../src/components/VtToast.vue"
 import VtIcon from "../../../src/components/VtIcon.vue"
@@ -10,6 +10,7 @@ import { VT_NAMESPACE, TYPE, POSITION, EVENTS } from "../../../src/ts/constants"
 import Simple from "../../utils/components/Simple.vue"
 import { EventBus } from "../../../src"
 import { normalizeToastComponent } from "../../../src/ts/utils"
+import * as useDraggableModule from "../../../src/ts/composables/useDraggable"
 
 const setData = (
   wrapper: VueWrapper<ComponentPublicInstance>,
@@ -38,6 +39,7 @@ describe("VtToast", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.restoreAllMocks()
   })
 
   describe("snapshots", () => {
@@ -162,8 +164,11 @@ describe("VtToast", () => {
       expect(vm.classes).toContain(POSITION.BOTTOM_CENTER)
     })
     it("updates with disableTransitions", () => {
+      jest.spyOn(useDraggableModule, "useDraggable").mockImplementation(() => ({
+        beingDragged: ref(false),
+        dragComplete: ref(true),
+      }))
       const wrapper = mountToast()
-      setData(wrapper, { disableTransitions: true })
       const vm = wrapper.vm as unknown as {
         classes: string[]
       }
@@ -222,160 +227,6 @@ describe("VtToast", () => {
       expect(vm.bodyClasses).toContain("myclass2")
     })
   })
-  describe("draggableStyle", () => {
-    it("returns empty if dragStart === dragPos.x", () => {
-      const wrapper = mountToast()
-      const vm = wrapper.vm as unknown as {
-        draggableStyle: {
-          transition?: string
-          opacity?: number
-          transform?: string
-        }
-      }
-      expect(vm.draggableStyle).toEqual({})
-    })
-    it("returns { transform, opacity } if beingDragged", () => {
-      const wrapper = mountToast()
-      setData(wrapper, { dragPos: { x: 10 }, beingDragged: true })
-      const vm = wrapper.vm as unknown as {
-        draggableStyle: {
-          transition?: string
-          opacity?: number
-          transform?: string
-        }
-        removalDistance: number
-        dragDelta: number
-      }
-      expect(vm.draggableStyle).toEqual({
-        transform: `translateX(${vm.dragDelta}px)`,
-        opacity: 1 - Math.abs(vm.dragDelta / vm.removalDistance),
-      })
-    })
-    it("Returns default values otherwise", () => {
-      const wrapper = mountToast()
-      setData(wrapper, { dragStart: 10, dragPos: { x: 0 } })
-      const vm = wrapper.vm as unknown as {
-        draggableStyle: {
-          transition?: string
-          opacity?: number
-          transform?: string
-        }
-      }
-      expect(vm.draggableStyle).toEqual({
-        transition: "transform 0.2s, opacity 0.2s",
-        transform: "translateX(0)",
-        opacity: 1,
-      })
-    })
-  })
-  describe("dragDelta", () => {
-    it("is being dragged", () => {
-      const wrapper = mountToast()
-      setData(wrapper, { beingDragged: true, dragPos: { x: 10 }, dragStart: 0 })
-      const vm = wrapper.vm as unknown as {
-        dragDelta: number
-      }
-      expect(vm.dragDelta).toBe(10)
-    })
-    it("is being dragged", () => {
-      const wrapper = mountToast()
-      setData(wrapper, {
-        beingDragged: false,
-        dragPos: { x: 10 },
-        dragStart: 0,
-      })
-      const vm = wrapper.vm as unknown as {
-        dragDelta: number
-      }
-      expect(vm.dragDelta).toBe(0)
-    })
-  })
-  describe("removalDistance", () => {
-    it("dragRect is a DOMRect", () => {
-      const wrapper = mountToast()
-      const dragRect: DOMRect = {
-        height: 10,
-        width: 10,
-        top: 10,
-        bottom: 10,
-        right: 10,
-        left: 0,
-        x: 10,
-        y: 10,
-        toJSON: () => ({}),
-      }
-      setData(wrapper, { dragRect, draggablePercent: 0.6 })
-      const vm = wrapper.vm as unknown as {
-        removalDistance: number
-      }
-      expect(vm.removalDistance).toBe(6)
-    })
-    it("dragRect is not a DOMRect", () => {
-      const wrapper = mountToast()
-      const dragRect = {}
-      setData(wrapper, { dragRect, draggablePercent: 0.6 })
-      const vm = wrapper.vm as unknown as {
-        removalDistance: number
-      }
-      expect(vm.removalDistance).toBe(0)
-    })
-  })
-  describe("mounted", () => {
-    it("calls draggableSetup if this.draggable is true", () => {
-      const spyOnDraggableSetup = jest.spyOn(VtToast.methods, "draggableSetup")
-
-      expect(spyOnDraggableSetup).not.toHaveBeenCalled()
-
-      mount(VtToast, {
-        props: {
-          draggable: true,
-          id: 1,
-          content: "content",
-        },
-      })
-
-      expect(spyOnDraggableSetup).toHaveBeenCalled()
-    })
-    it("does not call draggableSetup if this.draggable is false", () => {
-      const spyOnDraggableSetup = jest.spyOn(VtToast.methods, "draggableSetup")
-
-      expect(spyOnDraggableSetup).not.toHaveBeenCalled()
-
-      mount(VtToast, {
-        props: {
-          draggable: false,
-          id: 1,
-          content: "content",
-        },
-      })
-
-      expect(spyOnDraggableSetup).not.toHaveBeenCalled()
-    })
-  })
-  describe("beforeunmount", () => {
-    it("calls draggableCleanup if this.draggable is true", async () => {
-      const wrapper = mountToast({ draggable: true })
-      const vm = wrapper.vm as unknown as {
-        draggableCleanup(): void
-      }
-
-      const spyOnDraggableCleanup = (vm.draggableCleanup = jest.fn())
-      expect(spyOnDraggableCleanup).not.toHaveBeenCalled()
-      wrapper.unmount()
-      expect(spyOnDraggableCleanup).toHaveBeenCalled()
-    })
-    it("does not call draggableCleanup if this.draggable is false", () => {
-      const wrapper = mountToast({ draggable: false })
-      const vm = wrapper.vm as unknown as {
-        draggableCleanup(): void
-      }
-
-      const spyOnDraggableCleanup = (vm.draggableCleanup = jest.fn())
-      expect(spyOnDraggableCleanup).not.toHaveBeenCalled()
-      wrapper.unmount()
-      expect(spyOnDraggableCleanup).not.toHaveBeenCalled()
-    })
-  })
   describe("closeToast", () => {
     it("emits dismiss event", () => {
       const wrapper = mountToast({ id: "myId", eventBus })
@@ -388,6 +239,17 @@ describe("VtToast", () => {
     })
   })
   describe("clickHandler", () => {
+    it("do nothing if being dragged", () => {
+      jest.spyOn(useDraggableModule, "useDraggable").mockImplementation(() => ({
+        beingDragged: ref(true),
+        dragComplete: ref(false),
+      }))
+      const onClick = jest.fn()
+      const wrapper = mountToast({ onClick })
+      expect(onClick).not.toHaveBeenCalled()
+      wrapper.trigger("click")
+      expect(onClick).not.toHaveBeenCalled()
+    })
     it("calls onClick if defined", () => {
       const onClick = jest.fn()
       const wrapper = mountToast({ onClick })
@@ -397,28 +259,6 @@ describe("VtToast", () => {
       expect(onClick).not.toHaveBeenCalled()
       wrapper.trigger("click")
       expect(onClick).toHaveBeenCalledWith(vm.closeToast)
-    })
-    it("calls closeToast if closeOnClick and not beingDragged", () => {
-      const wrapper = mountToast({ closeOnClick: true })
-      setData(wrapper, { beingDragged: false })
-      const vm = wrapper.vm as unknown as {
-        closeToast(): void
-      }
-      const spyOnCloseToast = (vm.closeToast = jest.fn(vm.closeToast))
-      expect(spyOnCloseToast).not.toHaveBeenCalled()
-      wrapper.trigger("click")
-      expect(spyOnCloseToast).toHaveBeenCalled()
-    })
-    it("calls closeToast if closeOnClick and at the drag start", () => {
-      const wrapper = mountToast({ closeOnClick: true })
-      setData(wrapper, { beingDragged: true, dragStart: 0, dragPos: { x: 0 } })
-      const vm = wrapper.vm as unknown as {
-        closeToast(): void
-      }
-      const spyOnCloseToast = (vm.closeToast = jest.fn(vm.closeToast))
-      expect(spyOnCloseToast).not.toHaveBeenCalled()
-      wrapper.trigger("click")
-      expect(spyOnCloseToast).toHaveBeenCalled()
     })
     it("does not call closeToast if closeOnClick is false", () => {
       const wrapper = mountToast({ closeOnClick: false })
@@ -443,16 +283,14 @@ describe("VtToast", () => {
     })
   })
   describe("timeoutHandler", () => {
-    it("calls closeToast if ProgressBar emits close-toast", () => {
-      const wrapper = mountToast({ closeOnClick: false })
-      const vm = wrapper.vm as unknown as {
-        closeToast(): void
-      }
-      const spyOnCloseToast = (vm.closeToast = jest.fn(vm.closeToast))
+    it("calls closeToast if ProgressBar emits close-toast", async () => {
+      const id = "my-toast"
+      const wrapper = mountToast({ eventBus, id })
       const progressBar = wrapper.findComponent(VtProgressBar)
-      expect(spyOnCloseToast).not.toHaveBeenCalled()
+      expect(eventsEmmited.dismiss).not.toHaveBeenCalled()
       progressBar.vm.$emit("close-toast")
-      expect(spyOnCloseToast).toHaveBeenCalled()
+      await nextTick()
+      expect(eventsEmmited.dismiss).toHaveBeenCalledWith(id)
     })
   })
   describe("hover", () => {
@@ -502,221 +340,42 @@ describe("VtToast", () => {
       expect(vm.isRunning).toBe(true)
     })
   })
-  describe("onDragStart", () => {
-    it("sets correct values on drag start", () => {
+  describe("drag", () => {
+    it("pauses/resumes if draggable", async () => {
+      const beingDragged = ref(false)
+      jest
+        .spyOn(useDraggableModule, "useDraggable")
+        .mockImplementation(() => ({ beingDragged, dragComplete: ref(false) }))
       const wrapper = mountToast({ draggable: true })
-      setData(wrapper, {
-        beingDragged: false,
-        dragPos: { x: 0, y: 0 },
-        dragStart: 0,
-        dragRect: {},
-      })
       const vm = wrapper.vm as unknown as {
-        beingDragged: boolean
-        dragPos: { x: number; y: number }
-        dragStart: number
-        dragRect: DOMRect
-      }
-      expect(vm.beingDragged).toBe(false)
-      expect(vm.dragPos).toEqual({ x: 0, y: 0 })
-      expect(vm.dragStart).toBe(0)
-      expect(vm.dragRect).toEqual({})
-      wrapper.trigger("mousedown", {
-        clientX: 10,
-        clientY: 15,
-      })
-      expect(vm.beingDragged).toBe(true)
-      expect(vm.dragPos).toEqual({ x: 10, y: 15 })
-      expect(vm.dragStart).toBe(10)
-      expect(vm.dragRect).toEqual(wrapper.vm.$el.getBoundingClientRect())
-    })
-  })
-  describe("onDragMove", () => {
-    it("updates if beingDragged and isRunning", () => {
-      const wrapper = mountToast({ draggable: true })
-      const docWrapper = new DOMWrapper(document.body)
-      setData(wrapper, { beingDragged: false, isRunning: true })
-      const vm = wrapper.vm as unknown as {
-        beingDragged: boolean
-        dragPos: { x: number; y: number }
         isRunning: boolean
       }
       expect(vm.isRunning).toBe(true)
-      wrapper.trigger("mousedown", {
-        clientX: 10,
-        clientY: 15,
-      })
-      expect(vm.isRunning).toBe(true)
-      docWrapper.trigger("mousemove", {
-        clientX: 20,
-        clientY: 25,
-      })
-      expect(vm.beingDragged).toBe(true)
+      beingDragged.value = true
+      await nextTick()
       expect(vm.isRunning).toBe(false)
-      expect(vm.dragPos).toEqual({ x: 20, y: 25 })
-    })
-    it("event.preventDefault is called if being dragged", () => {
-      const wrapper = mountToast({ draggable: true })
-      setData(wrapper, { beingDragged: false, isRunning: true })
-      wrapper.trigger("mousedown", {
-        clientX: 0,
-        clientY: 0,
-      })
-      const event = new MouseEvent("mousemove", { clientX: 10, clientY: 15 })
-      const spyPreventDefault = jest.spyOn(event, "preventDefault")
-      expect(spyPreventDefault).not.toBeCalled()
-      window.dispatchEvent(event)
-      expect(spyPreventDefault).toBeCalled()
-    })
-    it("does nothing if not beingDragged", () => {
-      const wrapper = mountToast({ draggable: true })
-      const docWrapper = new DOMWrapper(document.body)
-      setData(wrapper, { beingDragged: false, isRunning: true })
-      const vm = wrapper.vm as unknown as {
-        beingDragged: boolean
-        dragPos: { x: number; y: number }
-        isRunning: boolean
-      }
-      expect(vm.isRunning).toBe(true)
-      docWrapper.trigger("mousemove", {
-        clientX: 20,
-        clientY: 25,
-      })
-      expect(vm.beingDragged).toBe(false)
-      expect(vm.isRunning).toBe(true)
-      expect(vm.dragPos).toEqual({ x: 0, y: 0 })
-    })
-  })
-  describe("onDragEnd", () => {
-    it("if drag ended after removalDistance, remove the component", async () => {
-      const wrapper = mountToast({ draggable: true })
-      const docWrapper = new DOMWrapper(document.body)
-      setData(wrapper, { beingDragged: false, isRunning: true })
-      const vm = wrapper.vm as unknown as {
-        beingDragged: boolean
-        dragPos: { x: number; y: number }
-        isRunning: boolean
-        dragDelta: number
-        removalDistance: number
-        closeToast(): void
-        disableTransitions: boolean
-      }
-      const spyCloseToast = (vm.closeToast = jest.fn(vm.closeToast))
-      wrapper.trigger("mousedown", {
-        clientX: 0,
-        clientY: 0,
-      })
-      docWrapper.trigger("mousemove", {
-        clientX: 1000,
-        clientY: 0,
-      })
-      expect(Math.abs(vm.dragDelta)).toBeGreaterThanOrEqual(vm.removalDistance)
-      expect(spyCloseToast).not.toHaveBeenCalled()
-      expect(vm.disableTransitions).toBe(false)
-      docWrapper.trigger("mouseup")
-      expect(spyCloseToast).not.toHaveBeenCalled()
-      expect(vm.disableTransitions).toBe(true)
-      await wrapper.vm.$nextTick()
-      expect(spyCloseToast).toHaveBeenCalled()
-    })
-    it("if drag ended before removalDistance but the mouse remains and pauseOnHover, pause", async () => {
-      const wrapper = mountToast({ draggable: true, pauseOnHover: true })
-      const docWrapper = new DOMWrapper(document.body)
-      setData(wrapper, { beingDragged: false, isRunning: true })
-      const vm = wrapper.vm as unknown as {
-        beingDragged: boolean
-        dragPos: { x: number; y: number }
-        isRunning: boolean
-        dragDelta: number
-        removalDistance: number
-        disableTransitions: boolean
-        dragRect: DOMRect
-      }
-      wrapper.trigger("mousedown", {
-        clientX: 0,
-        clientY: 0,
-      })
-      docWrapper.trigger("mousemove", {
-        clientX: 0,
-        clientY: 0,
-      })
-      setData(wrapper, {
-        dragRect: { x: 0, y: 0, bottom: 10, top: -10, left: -10, right: 10 },
-      })
-      expect(Math.abs(vm.dragDelta)).toBeLessThan(vm.removalDistance)
-      expect(vm.disableTransitions).toBe(false)
-      docWrapper.trigger("mouseup")
-      expect(vm.disableTransitions).toBe(false)
-      expect(vm.beingDragged).toBe(true)
-      await new Promise<void>(resolve => setTimeout(() => resolve()))
-      expect(vm.beingDragged).toBe(false)
-      expect(vm.isRunning).toBe(false)
-    })
-    it("if drag ended before removalDistance but the mouse remains and not pauseOnHover, resume", async () => {
-      const wrapper = mountToast({ draggable: true, pauseOnHover: false })
-      const docWrapper = new DOMWrapper(document.body)
-      setData(wrapper, { beingDragged: false, isRunning: true })
-      const vm = wrapper.vm as unknown as {
-        beingDragged: boolean
-        dragPos: { x: number; y: number }
-        isRunning: boolean
-        dragDelta: number
-        removalDistance: number
-        disableTransitions: boolean
-        dragRect: DOMRect
-      }
-      wrapper.trigger("mousedown", {
-        clientX: 0,
-        clientY: 0,
-      })
-      docWrapper.trigger("mousemove", {
-        clientX: 0,
-        clientY: 0,
-      })
-      setData(wrapper, {
-        dragRect: { x: 0, y: 0, bottom: 10, top: -10, left: -10, right: 10 },
-      })
-      expect(Math.abs(vm.dragDelta)).toBeLessThan(vm.removalDistance)
-      expect(vm.disableTransitions).toBe(false)
-      docWrapper.trigger("mouseup")
-      expect(vm.disableTransitions).toBe(false)
-      expect(vm.beingDragged).toBe(true)
-      await new Promise<void>(resolve => setTimeout(() => resolve()))
-      expect(vm.beingDragged).toBe(false)
+      beingDragged.value = false
+      await nextTick()
       expect(vm.isRunning).toBe(true)
     })
-    it("if drag ended before removalDistance and the mouse is outside, resume", async () => {
-      const wrapper = mountToast({ draggable: true, pauseOnHover: true })
-      const docWrapper = new DOMWrapper(document.body)
-      setData(wrapper, { beingDragged: false, isRunning: true })
-      const vm = wrapper.vm as unknown as {
-        beingDragged: boolean
-        dragPos: { x: number; y: number }
-        isRunning: boolean
-        dragDelta: number
-        removalDistance: number
-        disableTransitions: boolean
-        dragRect: DOMRect
-      }
-      wrapper.trigger("mousedown", {
-        clientX: 0,
-        clientY: 0,
-      })
-      docWrapper.trigger("mousemove", {
-        clientX: 0,
-        clientY: 100,
-      })
-      setData(wrapper, {
-        dragRect: { x: 0, y: 0, bottom: 10, top: -10, left: -10, right: 10 },
-      })
-      expect(Math.abs(vm.dragDelta)).toBeLessThan(vm.removalDistance)
-      expect(vm.disableTransitions).toBe(false)
-      docWrapper.trigger("mouseup")
-      expect(vm.disableTransitions).toBe(false)
-      expect(vm.beingDragged).toBe(true)
-      await new Promise<void>(resolve => setTimeout(() => resolve()))
-      expect(vm.beingDragged).toBe(false)
-      expect(vm.isRunning).toBe(true)
+    it("closes toast on drag end", async () => {
+      const dragComplete = ref(false)
+      jest
+        .spyOn(useDraggableModule, "useDraggable")
+        .mockImplementation(() => ({ beingDragged: ref(false), dragComplete }))
+      mountToast({ draggable: true, eventBus, id: "closesOnEnd" })
+
+      await nextTick()
+      expect(eventsEmmited.dismiss).not.toHaveBeenCalled()
+
+      dragComplete.value = true
+
+      await nextTick()
+      await nextTick()
+
+      expect(eventsEmmited.dismiss).toHaveBeenCalledWith("closesOnEnd")
+
+      dragComplete.value = false
     })
   })
 })

--- a/tests/unit/components/VtToast.spec.ts
+++ b/tests/unit/components/VtToast.spec.ts
@@ -15,7 +15,7 @@ const setData = (
   wrapper: VueWrapper<ComponentPublicInstance>,
   override: Record<string, unknown>
 ) => {
-  merge(wrapper.vm.$data, override)
+  merge(wrapper.vm, override)
 }
 
 const mountToast = ({ id, content, ...props }: ToastOptionsAndContent = {}) =>
@@ -507,17 +507,19 @@ describe("VtToast", () => {
       expect(spyOnCloseToast).toHaveBeenCalled()
     })
   })
-  describe("hoverPause", () => {
-    it("pauses on mouseenter if pauseOnHover", () => {
+  describe("hover", () => {
+    it("pauses/resumes if pauseOnHover", async () => {
       const wrapper = mountToast({ pauseOnHover: true })
       const vm = wrapper.vm as unknown as {
         isRunning: boolean
       }
       expect(vm.isRunning).toBe(true)
-      wrapper.trigger("mouseenter")
+      await wrapper.trigger("mouseenter")
       expect(vm.isRunning).toBe(false)
+      await wrapper.trigger("mouseleave")
+      expect(vm.isRunning).toBe(true)
     })
-    it("does not pause on mouseenter if not pauseOnHover", () => {
+    it("does not pause/resume if not pauseOnHover", () => {
       const wrapper = mountToast({ pauseOnHover: false })
       const vm = wrapper.vm as unknown as {
         isRunning: boolean
@@ -525,28 +527,6 @@ describe("VtToast", () => {
       expect(vm.isRunning).toBe(true)
       wrapper.trigger("mouseenter")
       expect(vm.isRunning).toBe(true)
-    })
-  })
-  describe("hoverPlay", () => {
-    it("resume on mouseleave if pauseOnHover", () => {
-      const wrapper = mountToast({ pauseOnHover: true })
-      setData(wrapper, { isRunning: false })
-      const vm = wrapper.vm as unknown as {
-        isRunning: boolean
-      }
-      expect(vm.isRunning).toBe(false)
-      wrapper.trigger("mouseleave")
-      expect(vm.isRunning).toBe(true)
-    })
-    it("does not resume on mouseleave if not pauseOnHover", () => {
-      const wrapper = mountToast({ pauseOnHover: false })
-      setData(wrapper, { isRunning: false })
-      const vm = wrapper.vm as unknown as {
-        isRunning: boolean
-      }
-      expect(vm.isRunning).toBe(false)
-      wrapper.trigger("mouseleave")
-      expect(vm.isRunning).toBe(false)
     })
   })
   describe("focusPause", () => {

--- a/tests/unit/ts/composables/useDraggable.spec.ts
+++ b/tests/unit/ts/composables/useDraggable.spec.ts
@@ -1,0 +1,324 @@
+/* eslint-disable vue/one-component-per-file */
+
+import { mount } from "@vue/test-utils"
+import {
+  computed,
+  defineComponent,
+  h,
+  nextTick,
+  reactive,
+  ref,
+  onMounted,
+  Ref,
+} from "vue"
+import { useDraggable } from "../../../../src/ts/composables/useDraggable"
+
+const activeText = "dragging"
+const inactiveText = "stopped"
+const completeText = "complete"
+
+type Props = Parameters<typeof useDraggable>[1]
+
+const TestComponent = (getEl?: (el: Ref<HTMLElement | undefined>) => void) =>
+  defineComponent({
+    props: {
+      draggablePercent: {
+        type: Number,
+        required: true,
+      },
+      draggable: {
+        type: Boolean,
+        required: true,
+      },
+    },
+    setup(props) {
+      const el = ref<HTMLElement>()
+      onMounted(() => getEl && getEl(el))
+      const { beingDragged, dragComplete } = useDraggable(el, props)
+      const text = computed(() => {
+        if (dragComplete.value) {
+          return completeText
+        }
+        return beingDragged.value ? activeText : inactiveText
+      })
+      return () =>
+        h("div", { ref: el, id: "outer" }, h("p", { id: "inner" }, text.value))
+    },
+  })
+
+describe("useDraggable", () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.restoreAllMocks()
+  })
+
+  const startPos: Pick<MouseEvent, "clientX" | "clientY"> = {
+    clientX: 0,
+    clientY: 0,
+  }
+  const clientRect: Omit<DOMRect, "toJSON"> = {
+    x: startPos.clientX,
+    y: startPos.clientY,
+    right: 10,
+    left: 0,
+    bottom: 0,
+    height: 0,
+    width: 0,
+    top: 0,
+  }
+
+  const getEl = (el: Ref<HTMLElement | undefined>) => {
+    if (el.value) {
+      jest
+        .spyOn(el.value, "getBoundingClientRect")
+        .mockImplementation(() => clientRect as DOMRect)
+    }
+  }
+
+  const getDragDistance = (draggablePercent: number) =>
+    (clientRect.right - clientRect.left) * draggablePercent
+
+  it("Returns valid object", async () => {
+    const consoleSpy = jest.spyOn(console, "warn").mockImplementation()
+
+    const el = ref()
+    const props = reactive<Props>({ draggable: true, draggablePercent: 0.6 })
+    const retuned = useDraggable(el, props)
+
+    // not-used-in-setup warnings
+    expect(consoleSpy).toBeCalledTimes(2)
+
+    expect(retuned.beingDragged.value).toBe(false)
+    expect(retuned.dragComplete.value).toBe(false)
+  })
+
+  it("Mounts and unmounts", async () => {
+    const props = reactive<Props>({ draggable: true, draggablePercent: 0.6 })
+    const wrapper = mount(TestComponent(getEl), { props })
+
+    const inner = wrapper.find("#inner")
+
+    expect(inner.text()).toEqual(inactiveText)
+
+    wrapper.unmount()
+  })
+
+  it("Does not drag if not draggable", async () => {
+    const props = reactive<Props>({ draggable: false, draggablePercent: 0.6 })
+    const wrapper = mount(TestComponent(getEl), { props })
+
+    const outer = wrapper.find("#outer")
+    const inner = wrapper.find("#inner")
+
+    expect(inner.text()).toEqual(inactiveText)
+
+    outer.element.dispatchEvent(
+      new window.MouseEvent("mousedown", { ...startPos })
+    )
+    await nextTick()
+
+    expect(inner.text()).toEqual(inactiveText)
+
+    window.dispatchEvent(
+      new window.MouseEvent("mousemove", {
+        clientX: startPos.clientX + getDragDistance(0.6),
+        clientY: startPos.clientY,
+      })
+    )
+    await nextTick()
+    expect(inner.text()).toEqual(inactiveText)
+  })
+
+  it("beingDragged not enough with mouse", async () => {
+    const props = reactive<Props>({ draggable: true, draggablePercent: 0.6 })
+    const wrapper = mount(TestComponent(getEl), { props })
+
+    const outer = wrapper.find("#outer")
+    const inner = wrapper.find("#inner")
+
+    expect(inner.text()).toEqual(inactiveText)
+
+    outer.element.dispatchEvent(
+      new window.MouseEvent("mousedown", { ...startPos })
+    )
+    await nextTick()
+
+    expect(inner.text()).toEqual(inactiveText)
+
+    // Get current position and calculate a move that is not enough to complete the drag
+    const dragDistance = getDragDistance(0.6) * 0.9
+    window.dispatchEvent(
+      new window.MouseEvent("mousemove", {
+        clientX: startPos.clientX + dragDistance,
+        clientY: startPos.clientY,
+      })
+    )
+    await nextTick()
+    expect(inner.text()).toEqual(activeText)
+
+    // End the drag
+    window.dispatchEvent(new window.MouseEvent("mouseup"))
+    await nextTick()
+    await new Promise(r => setTimeout(r))
+    expect(inner.text()).toEqual(inactiveText)
+  })
+
+  it("beingDragged not enough with touch", async () => {
+    const props = reactive<Props>({ draggable: true, draggablePercent: 0.6 })
+    const wrapper = mount(TestComponent(getEl), { props })
+
+    const outer = wrapper.find("#outer")
+    const inner = wrapper.find("#inner")
+
+    expect(inner.text()).toEqual(inactiveText)
+
+    outer.element.dispatchEvent(
+      new window.MouseEvent("touchstart", { ...startPos })
+    )
+    await nextTick()
+
+    expect(inner.text()).toEqual(inactiveText)
+
+    // Get current position and calculate a move that is not enough to complete the drag
+    const dragDistance = getDragDistance(0.6) * 0.9
+    window.dispatchEvent(
+      new window.MouseEvent("touchmove", {
+        clientX: startPos.clientX + dragDistance,
+        clientY: startPos.clientY,
+      })
+    )
+    await nextTick()
+    expect(inner.text()).toEqual(activeText)
+
+    // End the drag
+    window.dispatchEvent(new window.MouseEvent("touchend"))
+    await nextTick()
+    await new Promise(r => setTimeout(r))
+    expect(inner.text()).toEqual(inactiveText)
+  })
+
+  it("beingDragged and then dragComplete", async () => {
+    const props = reactive<Props>({ draggable: true, draggablePercent: 0.6 })
+    const wrapper = mount(TestComponent(getEl), { props })
+
+    const outer = wrapper.find("#outer")
+    const inner = wrapper.find("#inner")
+
+    expect(inner.text()).toEqual(inactiveText)
+
+    outer.element.dispatchEvent(
+      new window.MouseEvent("mousedown", { ...startPos })
+    )
+    await nextTick()
+
+    expect(inner.text()).toEqual(inactiveText)
+
+    // Get current position and calculate a move that is enough to complete the drag
+    const dragDistance = getDragDistance(0.6) * 1.1
+    window.dispatchEvent(
+      new window.MouseEvent("mousemove", {
+        clientX: startPos.clientX + dragDistance,
+        clientY: startPos.clientY,
+      })
+    )
+    await nextTick()
+    expect(inner.text()).toEqual(activeText)
+
+    // End the drag
+    window.dispatchEvent(new window.MouseEvent("mouseup"))
+    await nextTick()
+    await new Promise(r => setTimeout(r))
+    expect(inner.text()).toEqual(completeText)
+  })
+
+  it("styles are applied", async () => {
+    const props = reactive<Props>({ draggable: true, draggablePercent: 0.6 })
+    let _el: HTMLElement | undefined = undefined
+
+    const wrapper = mount(
+      TestComponent(e => {
+        getEl(e)
+        if (e.value) {
+          _el = e.value
+        }
+      }),
+      { props }
+    )
+
+    const outer = wrapper.find("#outer")
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(_el).toBeDefined()
+    if (!_el) {
+      return
+    }
+    const el = _el as HTMLElement
+
+    await nextTick()
+
+    // Before dragging, some styles should be set
+    expect(el.style.transform).toEqual("translateX(0px)")
+    expect(el.style.opacity).toEqual("1")
+    expect(el.style.transition).toEqual("")
+
+    // Drag starts
+    outer.element.dispatchEvent(
+      new window.MouseEvent("mousedown", { ...startPos })
+    )
+    await nextTick()
+
+    // Same styles are kept
+    expect(el.style.transform).toEqual("translateX(0px)")
+    expect(el.style.opacity).toEqual("1")
+    expect(el.style.transition).toEqual("")
+
+    // Drag a little bit
+    const removalDistance = getDragDistance(0.6)
+    const dragDistance = Math.floor(removalDistance * 0.8)
+    window.dispatchEvent(
+      new window.MouseEvent("mousemove", {
+        clientX: startPos.clientX + dragDistance,
+        clientY: startPos.clientY,
+      })
+    )
+    await nextTick()
+
+    // Styles reflect dragging
+    expect(el.style.transform).toEqual(`translateX(${dragDistance}px)`)
+    expect(el.style.opacity).toEqual(
+      `${1 - Math.abs(dragDistance / removalDistance)}`
+    )
+    expect(el.style.transition).toEqual("")
+
+    // End the drag
+    window.dispatchEvent(new window.MouseEvent("mouseup"))
+    await nextTick()
+    await new Promise(r => setTimeout(r))
+
+    // Return to initial styles with a transition
+    expect(el.style.transform).toEqual(`translateX(0px)`)
+    expect(el.style.opacity).toEqual("1")
+    expect(el.style.transition).toEqual("transform 0.2s, opacity 0.2s")
+
+    // Start again, move and end
+    outer.element.dispatchEvent(
+      new window.MouseEvent("mousedown", { ...startPos })
+    )
+    await nextTick()
+    window.dispatchEvent(
+      new window.MouseEvent("mousemove", {
+        clientX: startPos.clientX + removalDistance,
+        clientY: startPos.clientY,
+      })
+    )
+    await nextTick()
+    window.dispatchEvent(new window.MouseEvent("mouseup"))
+    await nextTick()
+    await new Promise(r => setTimeout(r))
+
+    // Styles are final
+    expect(el.style.transform).toEqual(`translateX(${removalDistance}px)`)
+    expect(el.style.opacity).toEqual("0")
+    expect(el.style.transition).toEqual("")
+  })
+})

--- a/tests/unit/ts/composables/useFocusable.spec.ts
+++ b/tests/unit/ts/composables/useFocusable.spec.ts
@@ -1,0 +1,117 @@
+/* eslint-disable vue/one-component-per-file */
+
+import { mount } from "@vue/test-utils"
+import { computed, defineComponent, h, nextTick, reactive, ref } from "vue"
+import { useFocusable } from "../../../../src/ts/composables/useFocusable"
+
+const activeText = "things"
+const inactiveText = "stuffs"
+
+type Props = Parameters<typeof useFocusable>[1]
+
+const TestComponent = defineComponent({
+  props: {
+    pauseOnFocusLoss: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  setup(props) {
+    const el = ref<HTMLElement>()
+    const { focused } = useFocusable(el, props)
+    const text = computed(() => (focused.value ? activeText : inactiveText))
+    return () =>
+      h("div", { ref: el, id: "outer" }, h("p", { id: "inner" }, text.value))
+  },
+})
+
+describe("useFocusable", () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.restoreAllMocks()
+  })
+
+  it("Returns valid object", async () => {
+    const consoleSpy = jest.spyOn(console, "warn").mockImplementation()
+
+    const el = ref()
+    const props = reactive<Props>({ pauseOnFocusLoss: false })
+    const retuned = useFocusable(el, props)
+
+    // not-used-in-setup warnings
+    expect(consoleSpy).toBeCalledTimes(2)
+
+    expect(retuned.focused.value).toBe(true)
+  })
+
+  it("adds and removes event listeners", () => {
+    const props = reactive<Props>({ pauseOnFocusLoss: true })
+
+    const addEventListenerSpy = jest.spyOn(window, "addEventListener")
+    const removeEventListenerSpy = jest.spyOn(window, "removeEventListener")
+
+    expect(addEventListenerSpy).not.toHaveBeenCalled()
+    expect(removeEventListenerSpy).not.toHaveBeenCalled()
+
+    const wrapper = mount(TestComponent, { props })
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(2)
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      "blur",
+      expect.any(Function)
+    )
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      "focus",
+      expect.any(Function)
+    )
+    expect(removeEventListenerSpy).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(2)
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(2)
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "blur",
+      expect.any(Function)
+    )
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "focus",
+      expect.any(Function)
+    )
+  })
+
+  it("focus and blur if pauseOnFocusLoss", async () => {
+    const props = reactive<Props>({ pauseOnFocusLoss: true })
+    const wrapper = mount(TestComponent, { props })
+
+    const inner = wrapper.find("#inner")
+
+    expect(inner.text()).toEqual(activeText)
+
+    window.dispatchEvent(new window.FocusEvent("blur"))
+    await nextTick()
+
+    expect(inner.text()).toEqual(inactiveText)
+
+    window.dispatchEvent(new window.FocusEvent("focus"))
+    await nextTick()
+
+    expect(inner.text()).toEqual(activeText)
+  })
+
+  it("does not focus and blur if not pauseOnFocusLoss", async () => {
+    const props = reactive<Props>({ pauseOnFocusLoss: false })
+    const wrapper = mount(TestComponent, { props })
+
+    const inner = wrapper.find("#inner")
+
+    expect(inner.text()).toEqual(activeText)
+
+    window.dispatchEvent(new window.FocusEvent("blur"))
+    await nextTick()
+
+    expect(inner.text()).not.toEqual(inactiveText)
+
+    wrapper.unmount()
+  })
+})

--- a/tests/unit/ts/composables/useHoverable.spec.ts
+++ b/tests/unit/ts/composables/useHoverable.spec.ts
@@ -1,0 +1,80 @@
+/* eslint-disable vue/one-component-per-file */
+
+import { mount } from "@vue/test-utils"
+import { computed, defineComponent, h, reactive, ref } from "vue"
+import { useHoverable } from "../../../../src/ts/composables/useHoverable"
+
+const activeText = "things"
+const inactiveText = "stuffs"
+
+type Props = Parameters<typeof useHoverable>[1]
+
+const TestComponent = defineComponent({
+  props: {
+    pauseOnHover: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  setup(props) {
+    const el = ref<HTMLElement>()
+    const { hovering } = useHoverable(el, props)
+    const text = computed(() => (hovering.value ? activeText : inactiveText))
+    return () =>
+      h("div", { ref: el, id: "outer" }, h("p", { id: "inner" }, text.value))
+  },
+})
+
+describe("useHoverable", () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.restoreAllMocks()
+  })
+
+  it("Returns valid object", async () => {
+    const consoleSpy = jest.spyOn(console, "warn").mockImplementation()
+
+    const el = ref()
+    const props = reactive<Props>({ pauseOnHover: false })
+    const retuned = useHoverable(el, props)
+
+    // not-used-in-setup warnings
+    expect(consoleSpy).toBeCalledTimes(2)
+
+    expect(retuned.hovering.value).toBe(false)
+  })
+
+  it("pause/resume if pauseOnHover", async () => {
+    const props = reactive<Props>({ pauseOnHover: true })
+    const wrapper = mount(TestComponent, { props })
+
+    const outer = wrapper.find("#outer")
+    const inner = wrapper.find("#inner")
+
+    expect(inner.text()).toEqual(inactiveText)
+
+    await outer.trigger("mouseenter")
+
+    expect(inner.text()).toEqual(activeText)
+
+    await outer.trigger("mouseleave")
+
+    expect(inner.text()).toEqual(inactiveText)
+  })
+
+  it("does not pause/resume if not pauseOnHover", async () => {
+    const props = reactive<Props>({ pauseOnHover: false })
+    const wrapper = mount(TestComponent, { props })
+
+    const outer = wrapper.find("#outer")
+    const inner = wrapper.find("#inner")
+
+    expect(inner.text()).toEqual(inactiveText)
+
+    await outer.trigger("mouseenter")
+
+    expect(inner.text()).not.toEqual(activeText)
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Migrates the Toast component from Options API to Composition API by transforming the event logic (hover, focus and drag) into composable hooks.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/vue-toastification/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
