### PR TITLE
Fix cannot assign to read only property 'exports' (issue #335)

### DIFF
--- a/composition/nuxt/index.js
+++ b/composition/nuxt/index.js
@@ -1,5 +1,5 @@
 const { useContext } = require("@nuxtjs/composition-api"); // eslint-disable-line @typescript-eslint/no-var-requires
 
-export const useToast = () => useContext().app.$toast;
+const useToast = () => useContext().app.$toast;
 
 module.exports = { useToast };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed export keyword from the `useToast()` method.

## Related Issue
#335 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/vue-toastification/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
