### PR TITLE
doc: add full example for overriding scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,9 @@ $vt-text-color-success: #000;
 @import "vue-toastification/src/scss/_progressBar";
 @import "vue-toastification/src/scss/_icon";
 @import "vue-toastification/src/scss/animations/_bounce";
+@import "vue-toastification/src/scss/animations/_fade";
+@import "vue-toastification/src/scss/animations/_slideBlurred";
+
 ```
 
 Then you import it when registering the plugin


### PR DESCRIPTION
I custom this funcy plugin with overriding scss and  
```
Vue.use(Toast, {   transition: "Vue-Toastification__fade"})
```

But the `fade` does not work. 

At last, I found that my scss copied from `readme.md` miss the related animation scss files.

so I think it's better add them.

