### PR TITLE
add typescript declare for nuxt Context

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -260,6 +260,10 @@ declare module "@nuxt/types" {
   interface NuxtAppOptions {
     $toast: ReturnType<typeof ToastInterface>;
   }
+                       
+  interface Context {
+    $toast: ReturnType<typeof ToastInterface>;
+  }
 
   interface NuxtOptions {
     toast?: NuxtModuleOptions;


### PR DESCRIPTION
need to use in nuxt pluginx
example: 
```
import type { Plugin } from '@nuxt/types';

const NuxtPlugin: Plugin = (context) => {
  context.$toast('toast enabled');
}
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/vue-toastification/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
