### PR TITLE
refactor: replace @import with @use/@forward to remove Sass deprecation warnings

### DIFF
--- a/src/scss/_closeButton.scss
+++ b/src/scss/_closeButton.scss
@@ -1,3 +1,5 @@
+@use "variables" as *;
+
 .#{$vt-namespace}__close-button {
   font-weight: bold;
   font-size: 24px;

--- a/src/scss/_icon.scss
+++ b/src/scss/_icon.scss
@@ -1,3 +1,5 @@
+@use "variables" as *;
+
 .#{$vt-namespace}__icon {
   margin: auto 18px auto 0px;
   background: transparent;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,0 +1,4 @@
+$trans-cubic-bezier: cubic-bezier(0.215, 0.61, 0.355, 1);
+@mixin timing-function {
+  animation-timing-function: $trans-cubic-bezier;
+}

--- a/src/scss/_progressBar.scss
+++ b/src/scss/_progressBar.scss
@@ -1,3 +1,5 @@
+@use "variables" as *;
+
 @keyframes scale-x-frames {
   0% {
     transform: scaleX(1);

--- a/src/scss/_toast.scss
+++ b/src/scss/_toast.scss
@@ -1,3 +1,5 @@
+@use "variables" as *;
+
 .#{$vt-namespace}__toast {
   display: inline-flex;
   position: relative;

--- a/src/scss/_toastContainer.scss
+++ b/src/scss/_toastContainer.scss
@@ -1,5 +1,5 @@
 @use "sass:math";
-
+@use "variables" as *;
 .#{$vt-namespace}__container {
   z-index: $vt-z-index;
   position: fixed;

--- a/src/scss/animations/_bounce.scss
+++ b/src/scss/animations/_bounce.scss
@@ -1,9 +1,6 @@
 // Bounce Animation taken from https://github.com/fkhadra/react-toastify
-$trans-cubic-bezier: cubic-bezier(0.215, 0.61, 0.355, 1);
-@mixin timing-function {
-  animation-timing-function: $trans-cubic-bezier;
-}
-
+@use "../variables" as *;
+@use "../mixins" as *;
 @keyframes bounceInRight {
   from,
   60%,

--- a/src/scss/animations/_fade.scss
+++ b/src/scss/animations/_fade.scss
@@ -1,12 +1,9 @@
-$trans-cubic-bezier: cubic-bezier(0.215, 0.61, 0.355, 1);
-@mixin timing-function {
-  animation-timing-function: $trans-cubic-bezier;
-}
-
+@use "../variables" as *;
+@use "../mixins" as *;
 /* ----------------------------------------------
  * Modified version from Animista
  * Animista is Licensed under FreeBSD License.
- * See http://animista.net/license for more info. 
+ * See http://animista.net/license for more info.
  * w: http://animista.net, t: @cssanimista
  * ---------------------------------------------- */
 

--- a/src/scss/animations/_slideBlurred.scss
+++ b/src/scss/animations/_slideBlurred.scss
@@ -1,12 +1,10 @@
-$trans-cubic-bezier: cubic-bezier(0.215, 0.61, 0.355, 1);
-@mixin timing-function {
-  animation-timing-function: $trans-cubic-bezier;
-}
+@use "../variables" as *;
+@use "../mixins" as *;
 
 /* ----------------------------------------------
  * Modified version from Animista
  * Animista is Licensed under FreeBSD License.
- * See http://animista.net/license for more info. 
+ * See http://animista.net/license for more info.
  * w: http://animista.net, t: @cssanimista
  * ---------------------------------------------- */
 

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -1,12 +1,13 @@
 @charset "UTF-8";
 
-@import "variables";
-@import "toastContainer";
-@import "toast";
-@import "closeButton";
-@import "progressBar";
-@import "icon";
+@forward "variables";
+@forward "toastContainer";
+@forward "toast";
+@forward "closeButton";
+@forward "progressBar";
+@forward "icon";
 
-@import "animations/bounce";
-@import "animations/fade";
-@import "animations/slideBlurred";
+@forward "animations/bounce";
+@forward "animations/fade";
+@forward "animations/slideBlurred";
+


### PR DESCRIPTION
## Summary
This PR replaces all deprecated `@import` statements with the new `@use` and `@forward` syntax introduced in Dart Sass.  
The change removes deprecation warnings during build and aligns the codebase with the current Sass best practices.

## Changes
- Replaced `@import` statements with `@use` or `@forward`.
- Namespaced variables and mixins where necessary.
- Resolved duplicate variable conflicts (e.g., `$trans-cubic-bezier`) by making global mixins.
- Verified that all styles compile correctly without warnings.

## Why
- `@import` is officially deprecated and will be removed in future Sass versions. Also there were many warning errors in build project
- `@use`/`@forward` provide better scoping, prevent global leaks, and improve maintainability.

## Notes
- All tests and style builds pass successfully.
- No breaking changes for consumers of the package.
